### PR TITLE
feat: password prompt colon

### DIFF
--- a/.changeset/ninety-tigers-chew.md
+++ b/.changeset/ninety-tigers-chew.md
@@ -1,0 +1,5 @@
+---
+"composable-cli": patch
+---
+
+added a colon on the end of email and password prompt

--- a/packages/composable-cli/src/commands/login/login-command.ts
+++ b/packages/composable-cli/src/commands/login/login-command.ts
@@ -442,12 +442,12 @@ async function promptUsernamePasswordLogin(
     [
       {
         type: "string",
-        message: "Enter your email address",
+        message: "Enter your email address:",
         name: "username",
       },
       {
         type: "password",
-        message: "Enter your password",
+        message: "Enter your password:",
         name: "password",
         mask: "*",
       },

--- a/packages/composable-cli/src/commands/login/login-command.ts
+++ b/packages/composable-cli/src/commands/login/login-command.ts
@@ -280,7 +280,7 @@ function createLoginTask({
                 if (!result.success) {
                   renderError({
                     headline: "Failed to authenticate",
-                    body: "There was a problem logging you in. Make sure that your username and password are correct.",
+                    body: "There was a problem logging you in. Make sure that your email address and password are correct.",
                   })
                   throw new CLITaskError({
                     message: result.message,


### PR DESCRIPTION
## Describe your changes
- replaced username with email for user facing output
- added a colon onto the password prompt
## Issue ticket number and link
n/a
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] I've added a Changeset for my changes - [Click here to learn what changesets are, and how to add one](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)
