### PR TITLE
fix: scripts support relative paths to config

### DIFF
--- a/packages/sdks/specs/config/redocly.yaml
+++ b/packages/sdks/specs/config/redocly.yaml
@@ -8,16 +8,16 @@ apis:
     decorators:
       override/operation-property-override:
         operationIds:
-          getACart: ../specs/overrides/getACart.yaml
+          getACart: ../overrides/getACart.yaml
   catalog_view@v1:
     output: ../bundled/catalog_view.yaml
     root: ../catalog_view.yaml
     decorators:
       override/component-merge:
-        mergeRef: ../specs/overrides/catalog_view_components.yaml
+        mergeRef: ../overrides/catalog_view_components.yaml
       override/operation-property-override:
         operationIds:
-          getByContextProduct: ../specs/overrides/getByContextProduct.yaml
+          getByContextProduct: ../overrides/getByContextProduct.yaml
 
 
 plugins:

--- a/packages/sdks/specs/plugins/decorators/component-merge.js
+++ b/packages/sdks/specs/plugins/decorators/component-merge.js
@@ -1,15 +1,33 @@
 // import { readFileAsStringSync } from "../../utils"
 const resolve1 = require("@redocly/openapi-core/lib/resolve")
 const fs = require("fs")
+const path = require("path")
 const _ = require("lodash")
 
 const ComponentMerge = (props) => {
-  const { mergeRef } = props
+  const { mergeRef: sourceMergeRef } = props
+
+  const redoclyConfigPath = path.resolve(__dirname, "../../config/redocly.yaml")
+
   return {
     Root: {
       leave(root, { report, location }) {
         try {
           const externalResolver = new resolve1.BaseResolver()
+
+          if (!sourceMergeRef) {
+            return
+          }
+
+          let mergeRef
+          if (path.isAbsolute(sourceMergeRef)) {
+            mergeRef = sourceMergeRef
+          } else {
+            mergeRef = path.resolve(
+              path.dirname(redoclyConfigPath),
+              sourceMergeRef,
+            )
+          }
 
           if (fs.lstatSync(mergeRef).isDirectory()) {
             throw new Error(

--- a/packages/sdks/specs/plugins/decorators/operation-property-override.js
+++ b/packages/sdks/specs/plugins/decorators/operation-property-override.js
@@ -1,9 +1,13 @@
 const resolve1 = require("@redocly/openapi-core/lib/resolve")
 const fs = require("fs")
+const path = require("path")
 const _ = require("lodash")
 
 const OperationPropertyOverride = (props) => {
   const { operationIds } = props
+
+  const redoclyConfigPath = path.resolve(__dirname, "../../config/redocly.yaml")
+
   return {
     Operation: {
       leave(operation, { report, location }) {
@@ -13,7 +17,23 @@ const OperationPropertyOverride = (props) => {
             `Parameter "operationIds" is not provided for "operation-property-override" rule`,
           )
         const operationId = operation.operationId
-        const operationFileRef = operationIds[operationId]
+
+        const opRawPath = operationIds[operationId]
+
+        if (!opRawPath) {
+          return
+        }
+
+        let operationFileRef
+        if (path.isAbsolute(opRawPath)) {
+          operationFileRef = opRawPath
+        } else {
+          operationFileRef = path.resolve(
+            path.dirname(redoclyConfigPath),
+            opRawPath,
+          )
+        }
+
         if (operationFileRef) {
           try {
             const externalResolver = new resolve1.BaseResolver()


### PR DESCRIPTION
## Describe your changes
scripts now support relative paths to files based on fixed config location
## Issue ticket number and link
n/a
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] I've added a Changeset for my changes - [Click here to learn what changesets are, and how to add one](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)
