### PR TITLE
build: fix shopper sdk dependencies.

### DIFF
--- a/packages/sdks/shopper/package.json
+++ b/packages/sdks/shopper/package.json
@@ -33,22 +33,20 @@
     "@hey-api/openapi-ts": "0.61.1",
     "@redocly/cli": "^1.21.0",
     "@redocly/openapi-core": "^1.21.0",
-    "@tanstack/react-query": "^5.52.1",
+    "@tanstack/react-query": "^5.69.0",
     "@types/ejs": "^3.1.5",
     "ejs": "^3.1.10",
     "lodash": "^4.17.21",
     "typescript": "^5.5.3"
   },
   "dependencies": {
-    "@hey-api/client-fetch": "0.6.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "@hey-api/client-fetch": "0.6.0"
   },
   "publishConfig": {
     "access": "public"
   },
   "peerDependencies": {
-    "@tanstack/react-query": "^5.52.1"
+    "@tanstack/react-query": "^5.69.0"
   },
   "peerDependenciesMeta": {
     "@tanstack/react-query": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1895,12 +1895,6 @@ importers:
       '@hey-api/client-fetch':
         specifier: 0.6.0
         version: 0.6.0
-      react:
-        specifier: ^19.0.0
-        version: 19.0.0
-      react-dom:
-        specifier: ^19.0.0
-        version: 19.0.0(react@19.0.0)
     devDependencies:
       '@hey-api/openapi-ts':
         specifier: 0.61.1
@@ -1912,8 +1906,8 @@ importers:
         specifier: ^1.21.0
         version: 1.27.1
       '@tanstack/react-query':
-        specifier: ^5.52.1
-        version: 5.63.0(react@19.0.0)
+        specifier: ^5.69.0
+        version: 5.69.0(react@18.3.1)
       '@types/ejs':
         specifier: ^3.1.5
         version: 3.1.5
@@ -11148,7 +11142,7 @@ packages:
       redoc: 2.2.0(core-js@3.33.1)(enzyme@3.11.0)(mobx@6.13.5)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.14)
       semver: 7.5.4
       simple-websocket: 9.1.0
-      styled-components: 6.1.14(react-dom@19.0.0)(react@19.0.0)
+      styled-components: 6.1.14(react-dom@18.3.1)(react@18.3.1)
       yargs: 17.0.1
     transitivePeerDependencies:
       - bufferutil
@@ -12537,8 +12531,8 @@ packages:
   /@tanstack/query-core@5.51.21:
     resolution: {integrity: sha512-POQxm42IUp6n89kKWF4IZi18v3fxQWFRolvBA6phNVmA8psdfB1MvDnGacCJdS+EOX12w/CyHM62z//rHmYmvw==}
 
-  /@tanstack/query-core@5.62.16:
-    resolution: {integrity: sha512-9Sgft7Qavcd+sN0V25xVyo0nfmcZXBuODy3FVG7BMWTg1HMLm8wwG5tNlLlmSic1u7l1v786oavn+STiFaPH2g==}
+  /@tanstack/query-core@5.69.0:
+    resolution: {integrity: sha512-Kn410jq6vs1P8Nm+ZsRj9H+U3C0kjuEkYLxbiCyn3MDEiYor1j2DGVULqAz62SLZtUZ/e9Xt6xMXiJ3NJ65WyQ==}
     dev: true
 
   /@tanstack/query-devtools@5.32.1:
@@ -12564,13 +12558,13 @@ packages:
       '@tanstack/query-core': 5.51.21
       react: 18.3.1
 
-  /@tanstack/react-query@5.63.0(react@19.0.0):
-    resolution: {integrity: sha512-QWizLzSiog8xqIRYmuJRok9VELlXVBAwtINgVCgW1SNvamQwWDO5R0XFSkjoBEj53x9Of1KAthLRBUC5xmtVLQ==}
+  /@tanstack/react-query@5.69.0(react@18.3.1):
+    resolution: {integrity: sha512-Ift3IUNQqTcaFa1AiIQ7WCb/PPy8aexZdq9pZWLXhfLcLxH0+PZqJ2xFImxCpdDZrFRZhLJrh76geevS5xjRhA==}
     peerDependencies:
       react: ^18 || ^19
     dependencies:
-      '@tanstack/query-core': 5.62.16
-      react: 19.0.0
+      '@tanstack/query-core': 5.69.0
+      react: 18.3.1
     dev: true
 
   /@testing-library/dom@9.3.3:
@@ -26001,14 +25995,6 @@ packages:
       react: 18.3.1
       scheduler: 0.23.2
 
-  /react-dom@19.0.0(react@19.0.0):
-    resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
-    peerDependencies:
-      react: ^19.0.0
-    dependencies:
-      react: 19.0.0
-      scheduler: 0.25.0
-
   /react-element-to-jsx-string@15.0.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==}
     peerDependencies:
@@ -26385,10 +26371,6 @@ packages:
     dependencies:
       loose-envify: 1.4.0
 
-  /react@19.0.0:
-    resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
-    engines: {node: '>=0.10.0'}
-
   /read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
     dependencies:
@@ -26547,7 +26529,7 @@ packages:
       react-tabs: 6.1.0(react@18.3.1)
       slugify: 1.4.7
       stickyfill: 1.1.1
-      styled-components: 6.1.14(react-dom@19.0.0)(react@19.0.0)
+      styled-components: 6.1.14(react-dom@18.3.1)(react@18.3.1)
       swagger2openapi: 7.0.8
       url-template: 2.0.8
     transitivePeerDependencies:
@@ -27140,9 +27122,6 @@ packages:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
     dependencies:
       loose-envify: 1.4.0
-
-  /scheduler@0.25.0:
-    resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
   /schema-dts@1.1.2(typescript@5.5.4):
     resolution: {integrity: sha512-MpNwH0dZJHinVxk9bT8XUdjKTxMYrA5bLtrrGmFA6PTLwlOKnhi67XoRd6/ty+Djt6ZC0slR57qFhZDNMI6DhQ==}
@@ -28242,7 +28221,7 @@ packages:
       inline-style-parser: 0.1.1
     dev: false
 
-  /styled-components@6.1.14(react-dom@19.0.0)(react@19.0.0):
+  /styled-components@6.1.14(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-KtfwhU5jw7UoxdM0g6XU9VZQFV4do+KrM8idiVCH5h4v49W+3p3yMe0icYwJgZQZepa5DbH04Qv8P0/RdcLcgg==}
     engines: {node: '>= 16'}
     peerDependencies:
@@ -28255,8 +28234,8 @@ packages:
       css-to-react-native: 3.2.0
       csstype: 3.1.3
       postcss: 8.4.38
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       shallowequal: 1.1.0
       stylis: 4.3.2
       tslib: 2.6.2


### PR DESCRIPTION
## Describe your changes
Previous MR https://github.com/elasticpath/composable-frontend/pull/382 introduced a hard dependency of on react into our gen 2 shopper sdk to resolve a react version conflict issue. This MR removes that dep as it shouldn't be included and bumps the tanstack react query peer dependency to fix the original build issue.
## Issue ticket number and link
n/a
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] I've added a Changeset for my changes - [Click here to learn what changesets are, and how to add one](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)
