### PR TITLE
build: ignore example apps in changesets configuration

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,12 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["algolia", "simple", "payments", "composable-cli-docs"]
+  "ignore": [
+    "algolia",
+    "simple",
+    "payments",
+    "memberships",
+    "composable-cli-docs",
+    "commerce-essentials-storefront"
+  ]
 }


### PR DESCRIPTION
## Describe your changes

- Updated .changeset/config.json to ignore additional example applications in the changeset process
- Added memberships and commerce-essentials-storefront to the ignored packages list

This change ensures that example applications are not included in the version management and release process handled by Changesets. By ignoring these example apps, we prevent unnecessary version bumps and releases for applications that are meant for demonstration purposes only.

## Issue ticket number and link
n/a
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] I've added a Changeset for my changes - [Click here to learn what changesets are, and how to add one](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)
