### PR TITLE
feat: add a storage key option so getCartId can support multiple carts

### DIFF
--- a/.changeset/witty-seas-appear.md
+++ b/.changeset/witty-seas-appear.md
@@ -1,0 +1,5 @@
+---
+"@epcc-sdk/sdks-shopper": patch
+---
+
+Add a storage key option so getCartId can support multiple carts

--- a/packages/sdks/shopper/src/utils/get-cart-id.ts
+++ b/packages/sdks/shopper/src/utils/get-cart-id.ts
@@ -1,5 +1,5 @@
 import { PERSISTED_CART_STORAGE_KEY } from "./initialize-cart"
 
-export function getCartId() {
-  return localStorage.getItem(PERSISTED_CART_STORAGE_KEY)
+export function getCartId(options?: { storageKey?: string }) {
+  return localStorage.getItem(options?.storageKey ?? PERSISTED_CART_STORAGE_KEY)
 }


### PR DESCRIPTION
## Describe your changes
# Add Support for Multiple Carts in SDK Shopper Package

This PR enhances the `getCartId` utility function in the `@epcc-sdk/sdks-shopper` package by adding an optional `storageKey` parameter. This improvement allows applications to manage multiple carts simultaneously by specifying different storage keys for each cart.

## Changes
- Added an optional `storageKey` parameter to the `getCartId` function
- The function now uses the provided storage key or falls back to the default key
- Maintains backward compatibility with existing implementations

## Benefits
- Enables multi-cart functionality in applications
- Provides flexibility for different shopping scenarios (wishlist, saved for later, etc.)
- Aligns `getCartId` functionality with the existing pattern in `initializeCart`

## Testing
Tested with multiple carts using different storage keys to ensure proper isolation and retrieval.
## Issue ticket number and link
n/a
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] I've added a Changeset for my changes - [Click here to learn what changesets are, and how to add one](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)
