### PR TITLE
fix: tanstack query correctly exported

### DIFF
--- a/packages/sdks/shopper/README.md
+++ b/packages/sdks/shopper/README.md
@@ -2,6 +2,26 @@
 
 Below you’ll find instructions on how to install, set up, and use the client, along with a list of available operations.
 
+## React Query Support
+
+This SDK provides optional React Query hooks for React applications. To use them, you need to:
+
+1. Install `@tanstack/react-query` as a peer dependency:
+   ```bash
+   npm install @tanstack/react-query
+   # or
+   pnpm install @tanstack/react-query
+   # or
+   yarn add @tanstack/react-query
+   ```
+
+2. Import hooks from the `/react-query` subpath:
+   ```ts
+   import { useGetByContextProduct } from "@epcc-sdk/sdks-shopper/react-query";
+   ```
+
+**Note**: If you're not using React or React Query, you can use the SDK without installing `@tanstack/react-query`. The main exports work independently.
+
 ## Features
 
 - type-safe response data and errors

--- a/packages/sdks/shopper/README.md
+++ b/packages/sdks/shopper/README.md
@@ -1,6 +1,7 @@
 # @epcc-sdk/sdks-shopper SDK
 
-Below you’ll find instructions on how to install, set up, and use the client, along with a list of available operations.
+Below you'll find instructions on how to install, set up, and use the client, along with a list of available operations.
+
 
 ## React Query Support
 
@@ -22,6 +23,7 @@ This SDK provides optional React Query hooks for React applications. To use them
 
 **Note**: If you're not using React or React Query, you can use the SDK without installing `@tanstack/react-query`. The main exports work independently.
 
+
 ## Features
 
 - type-safe response data and errors
@@ -31,6 +33,7 @@ This SDK provides optional React Query hooks for React applications. To use them
 - minimal learning curve thanks to extending the underlying technology
 
 ---
+
 
 ## Installation
 
@@ -484,6 +487,7 @@ const product = await getByContextProduct({
 - **`getAllFiles`** (`GET /v2/files`)
 
 - **`getAFile`** (`GET /v2/files/{fileID}`)
+
 
 
 

--- a/packages/sdks/shopper/package.json
+++ b/packages/sdks/shopper/package.json
@@ -17,6 +17,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./react-query": {
+      "import": {
+        "types": "./dist/react-query.d.ts",
+        "default": "./dist/react-query.mjs"
+      },
+      "require": {
+        "types": "./dist/react-query.d.cts",
+        "default": "./dist/react-query.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/sdks/shopper/readme-fragments/README.md
+++ b/packages/sdks/shopper/readme-fragments/README.md
@@ -1,0 +1,19 @@
+# README Fragments
+
+This directory contains custom fragments that are injected into the auto-generated README during the build process.
+
+## Available Injection Points
+
+- `afterIntro.md` - Content inserted after the main introduction
+- `beforeInstallation.md` - Content inserted before the Installation section
+- `afterOperations.md` - Content inserted after the Available Operations section
+
+## Usage
+
+1. Create a markdown file (`.md`) or EJS template (`.ejs`) with one of the supported names
+2. The content will be automatically included when running `pnpm oas:openapi-ts`
+3. The fragments support full markdown syntax
+
+## Example
+
+The `afterIntro.md` file in this directory adds React Query documentation to the README.

--- a/packages/sdks/shopper/readme-fragments/afterIntro.md
+++ b/packages/sdks/shopper/readme-fragments/afterIntro.md
@@ -1,0 +1,19 @@
+## React Query Support
+
+This SDK provides optional React Query hooks for React applications. To use them, you need to:
+
+1. Install `@tanstack/react-query` as a peer dependency:
+   ```bash
+   npm install @tanstack/react-query
+   # or
+   pnpm install @tanstack/react-query
+   # or
+   yarn add @tanstack/react-query
+   ```
+
+2. Import hooks from the `/react-query` subpath:
+   ```ts
+   import { useGetByContextProduct } from "@epcc-sdk/sdks-shopper/react-query";
+   ```
+
+**Note**: If you're not using React or React Query, you can use the SDK without installing `@tanstack/react-query`. The main exports work independently.

--- a/packages/sdks/shopper/src/index.ts
+++ b/packages/sdks/shopper/src/index.ts
@@ -1,5 +1,4 @@
 export * from "./client"
-export * from "./client/@tanstack/react-query.gen"
 import { type Client, createClient } from "@hey-api/client-fetch"
 export { createClient, type Client }
 export { client } from "./client/sdk.gen"

--- a/packages/sdks/shopper/src/react-query.ts
+++ b/packages/sdks/shopper/src/react-query.ts
@@ -1,0 +1,2 @@
+// React Query exports - requires @tanstack/react-query to be installed
+export * from "./client/@tanstack/react-query.gen"

--- a/packages/sdks/specs/heyapi/plugins/types.d.ts
+++ b/packages/sdks/specs/heyapi/plugins/types.d.ts
@@ -19,4 +19,9 @@ export interface Config {
    * Optional target operation to include in the README.
    */
   targetOperation?: string
+  /**
+   * Optional path to custom fragments directory.
+   * @default "./readme-fragments"
+   */
+  fragmentsPath?: string
 }

--- a/packages/sdks/specs/heyapi/readme-gen/readmeTemplate.ejs
+++ b/packages/sdks/specs/heyapi/readme-gen/readmeTemplate.ejs
@@ -1,6 +1,10 @@
 # <%= name %> SDK
 
-Below you’ll find instructions on how to install, set up, and use the client, along with a list of available operations.
+Below you'll find instructions on how to install, set up, and use the client, along with a list of available operations.
+<% if (hasCustomFragments && customFragments.afterIntro) { %>
+
+<%- customFragments.afterIntro %>
+<% } %>
 
 ## Features
 
@@ -11,6 +15,10 @@ Below you’ll find instructions on how to install, set up, and use the client, 
 - minimal learning curve thanks to extending the underlying technology
 
 ---
+<% if (hasCustomFragments && customFragments.beforeInstallation) { %>
+
+<%- customFragments.beforeInstallation %>
+<% } %>
 
 ## Installation
 
@@ -35,5 +43,9 @@ yarn add <%= name %>
 ## Available Operations
 
 <%- include('partials/operationList') %>
+<% if (hasCustomFragments && customFragments.afterOperations) { %>
+
+<%- customFragments.afterOperations %>
+<% } %>
 
 ---


### PR DESCRIPTION
## Describe your changes
Fix React Query optional dependency issue by separating exports into `/react-query` subpath. Non-React users can now use the SDK without installing @tanstack/react-query.
## Issue ticket number and link
n/a
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] I've added a Changeset for my changes - [Click here to learn what changesets are, and how to add one](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)
