### PR TITLE
feat: add built in auth

### DIFF
--- a/.changeset/fluffy-comics-pump.md
+++ b/.changeset/fluffy-comics-pump.md
@@ -1,0 +1,5 @@
+---
+"@epcc-sdk/sdks-shopper": patch
+---
+
+Added built in authentication helper

--- a/examples/authentication-local-storage/src/app/auth/StorefrontProvider.tsx
+++ b/examples/authentication-local-storage/src/app/auth/StorefrontProvider.tsx
@@ -1,88 +1,35 @@
 "use client"
 
-import React, { useEffect } from "react"
-import {
-  AccessTokenResponse,
-  client,
-  createAnAccessToken,
-} from "@epcc-sdk/sdks-shopper"
-import { CREDENTIALS_COOKIE_KEY } from "../constants"
+import React from "react"
+import { configureClient } from "@epcc-sdk/sdks-shopper"
 
-function tokenExpired(expires: number): boolean {
-  return Math.floor(Date.now() / 1000) >= expires
+// Configure the client immediately when the module is loaded
+const clientId = process.env.NEXT_PUBLIC_EPCC_CLIENT_ID
+const baseUrl = process.env.NEXT_PUBLIC_EPCC_ENDPOINT_URL
+
+if (!clientId) {
+  throw new Error("Missing storefront client id")
 }
 
-client.setConfig({
-  baseUrl: process.env.NEXT_PUBLIC_EPCC_ENDPOINT_URL!,
-})
+if (!baseUrl) {
+  throw new Error("Missing storefront endpoint URL")
+}
+
+// Configure the SDK client with built-in auth
+configureClient(
+  {
+    baseUrl,
+  },
+  {
+    clientId,
+    storage: "localStorage", // Use localStorage to persist tokens
+  },
+)
 
 export function StorefrontProvider({
   children,
 }: {
   children: React.ReactNode
 }) {
-  // Auto-authenticate if not already authenticated
-  useEffect(() => {
-    const interceptor: Parameters<
-      typeof client.interceptors.request.use
-    >[0] = async (request) => {
-      // Bypass interceptor logic for token requests to prevent infinite loop
-      if (request.url?.includes("/oauth/access_token")) {
-        return request
-      }
-
-      let credentials = JSON.parse(
-        localStorage.getItem(CREDENTIALS_COOKIE_KEY) ?? "{}",
-      ) as AccessTokenResponse | undefined
-
-      // check if token expired or missing
-      if (
-        !credentials?.access_token ||
-        (credentials.expires && tokenExpired(credentials.expires))
-      ) {
-        const clientId = process.env.NEXT_PUBLIC_EPCC_CLIENT_ID
-
-        if (!clientId) {
-          throw new Error("Missing storefront client id")
-        }
-
-        const authResponse = await createAnAccessToken({
-          body: {
-            grant_type: "implicit",
-            client_id: clientId,
-          },
-        })
-
-        /**
-         * Check response did not fail
-         */
-        if (!authResponse.data) {
-          throw new Error("Failed to get access token")
-        }
-
-        const token = authResponse.data
-
-        // Store the credentials in localStorage
-        localStorage.setItem(CREDENTIALS_COOKIE_KEY, JSON.stringify(token))
-        credentials = token
-      }
-
-      if (credentials?.access_token) {
-        request.headers.set(
-          "Authorization",
-          `Bearer ${credentials.access_token}`,
-        )
-      }
-      return request
-    }
-
-    // Add request interceptor to include the token in requests
-    client.interceptors.request.use(interceptor)
-
-    return () => {
-      client.interceptors.request.eject(interceptor)
-    }
-  }, [])
-
   return <>{children}</>
 }

--- a/examples/authentication-local-storage/src/app/client-component.tsx
+++ b/examples/authentication-local-storage/src/app/client-component.tsx
@@ -11,10 +11,16 @@ export function ClientComponent() {
   const [isAuthenticated, setIsAuthenticated] = useState(false)
 
   const fetchProducts = async () => {
-    const response = await getByContextAllProducts()
-    setProducts(response.data?.data || [])
-    if (response.data?.data && response.data?.data.length > 0) {
-      setIsAuthenticated(true)
+    try {
+      console.log("Fetching products...")
+      const response = await getByContextAllProducts()
+      console.log("Products response:", response)
+      setProducts(response.data?.data || [])
+      if (response.data?.data && response.data?.data.length > 0) {
+        setIsAuthenticated(true)
+      }
+    } catch (error) {
+      console.error("Error fetching products:", error)
     }
   }
 

--- a/examples/authentication-local-storage/src/app/constants.ts
+++ b/examples/authentication-local-storage/src/app/constants.ts
@@ -1,3 +1,0 @@
-export const EPCC_ENDPOINT_URL = process.env.NEXT_PUBLIC_EPCC_ENDPOINT_URL
-export const COOKIE_PREFIX_KEY = "_store"
-export const CREDENTIALS_COOKIE_KEY = `${COOKIE_PREFIX_KEY}_ep_credentials`

--- a/packages/sdks/shopper/src/auth/configure-client.test.ts
+++ b/packages/sdks/shopper/src/auth/configure-client.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { makeJwtExpIn } from "../test/utils"
+
+// Mock SDK modules before imports
+vi.mock("../client/sdk.gen", () => ({
+  client: {
+    setConfig: vi.fn(),
+    getConfig: vi.fn(() => ({
+      baseUrl: "https://api.example.com",
+      headers: {},
+      fetch: vi.fn(),
+    })),
+  },
+  createAnAccessToken: vi.fn(),
+}))
+
+vi.mock("@hey-api/client-fetch", () => ({
+  createClient: vi.fn(),
+  createConfig: vi.fn((cfg?: any) => cfg ?? {}),
+}))
+
+import { configureClient, createShopperClient } from "./configure-client"
+import { client as singleton, createAnAccessToken } from "../client/sdk.gen"
+import { createClient as sdkCreateClient } from "@hey-api/client-fetch"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Clear any stored tokens
+  localStorage.clear()
+  // Ensure createClient has the default implementation
+  ;(sdkCreateClient as any).mockImplementation((config?: any) => ({
+    ...config,
+    getConfig: () => config,
+  }))
+})
+
+describe("configureClient (singleton)", () => {
+  it("installs auth-wrapped fetch (adds Authorization) and normalizes headers", async () => {
+    const baseFetch = vi
+      .fn()
+      .mockResolvedValue(new Response("ok", { status: 200 }))
+
+    // the fresh bare client (from token provider) can be any object
+    ;(sdkCreateClient as any).mockReturnValueOnce({ __tag: "bare" })
+    ;(createAnAccessToken as any).mockResolvedValueOnce({
+      data: { access_token: makeJwtExpIn(60) },
+      error: undefined,
+    })
+
+    configureClient(
+      {
+        baseUrl: "https://api.example.com",
+        headers: { "x-one": 1 as unknown as string }, // non-string -> should normalize to "1"
+        fetch: baseFetch,
+      },
+      {
+        clientId: "CID",
+      },
+    )
+
+    expect(singleton.setConfig).toHaveBeenCalledTimes(1)
+    const cfg = (singleton.setConfig as any).mock.calls[0][0]
+    expect(cfg.baseUrl).toBe("https://api.example.com")
+    expect(cfg.headers).toEqual({ "x-one": "1" }) // normalized
+    expect(typeof cfg.fetch).toBe("function")
+
+    // invoke installed fetch; because of toStandardFetch, baseFetch recei[ves a Request
+    await cfg.fetch("https://api.example.com/resource")
+    expect(baseFetch).toHaveBeenCalledTimes(1)
+    const req = (baseFetch as any).mock.calls[0][0] as Request
+    expect(req instanceof Request).toBe(true)
+    expect(req.headers.get("authorization")).toMatch(/^Bearer /)
+  })
+
+  it("wrapUserFetch=false returns a standard-shaped fetch that leaves Authorization untouched", async () => {
+    const baseFetch = vi
+      .fn()
+      .mockResolvedValue(new Response("ok", { status: 200 }))
+
+    ;(sdkCreateClient as any).mockReturnValueOnce({ __tag: "bare" })
+    ;(createAnAccessToken as any).mockResolvedValueOnce({
+      data: { access_token: makeJwtExpIn(60) },
+      error: undefined,
+    })
+
+    configureClient(
+      {
+        baseUrl: "https://api.example.com",
+        fetch: baseFetch,
+      },
+      {
+        clientId: "CID",
+        wrapUserFetch: false,
+      },
+    )
+
+    const cfg = (singleton.setConfig as any).mock.calls[0][0]
+    await cfg.fetch("https://api.example.com/resource", { headers: { x: "y" } })
+
+    // baseFetch is called with a Request (toStandardFetch)
+    const req = (baseFetch as any).mock.calls[0][0] as Request
+    expect(req.headers.get("authorization")).toBeNull()
+    expect(req.headers.get("x")).toBe("y")
+  })
+})
+
+describe("createShopperClient (factory)", () => {
+  it("returns a new instance configured with authed fetch", async () => {
+    const baseFetch = vi
+      .fn()
+      .mockResolvedValue(new Response("ok", { status: 200 }))
+
+    // Track calls to createClient
+    const createClientCalls: any[] = []
+    ;(sdkCreateClient as any).mockImplementation((cfg: any) => {
+      createClientCalls.push(cfg)
+      // First call is from token provider, second is main client
+      if (createClientCalls.length === 1) {
+        return { __tag: "bare" }
+      }
+      return { __clientTag: "mocked" }
+    })
+    
+    ;(createAnAccessToken as any).mockImplementation(() => {
+      // Return the structure that the token provider expects
+      return Promise.resolve({
+        data: { 
+          access_token: makeJwtExpIn(60),
+          expires_in: 3600,
+          token_type: "Bearer"
+        },
+        error: undefined,
+      })
+    })
+
+    createShopperClient(
+      {
+        baseUrl: "https://api.example.com",
+        fetch: baseFetch,
+        headers: { "x-two": "2" },
+      },
+      {
+        clientId: "CID",
+      },
+    )
+
+    // The second call to createClient should have the auth-wrapped fetch
+    expect(createClientCalls.length).toBeGreaterThanOrEqual(1)
+    const mainClientConfig = createClientCalls[createClientCalls.length - 1]
+    expect(mainClientConfig.baseUrl).toBe("https://api.example.com")
+    expect(typeof mainClientConfig.fetch).toBe("function")
+
+    // Test the auth-wrapped fetch - this should trigger token fetching
+    // Use string URL like the first test does
+    await mainClientConfig.fetch("https://api.example.com/something")
+    
+    // Auth should have been applied
+    expect(baseFetch).toHaveBeenCalled()
+    const req = (baseFetch as any).mock.calls[0][0] as Request
+    expect(req instanceof Request).toBe(true)
+    expect(req.headers.get("authorization")).toMatch(/^Bearer /)
+    
+    // Test that user headers are preserved
+    await mainClientConfig.fetch("https://api.example.com/with-headers", { headers: { "x-two": "2" } })
+    const req2 = (baseFetch as any).mock.calls[1][0] as Request
+    expect(req2.headers.get("x-two")).toBe("2")
+    expect(req2.headers.get("authorization")).toMatch(/^Bearer /)
+  })
+})

--- a/packages/sdks/shopper/src/auth/configure-client.test.ts
+++ b/packages/sdks/shopper/src/auth/configure-client.test.ts
@@ -64,8 +64,8 @@ describe("configureClient (singleton)", () => {
     expect(cfg.headers).toEqual({ "x-one": "1" }) // normalized
     expect(typeof cfg.fetch).toBe("function")
 
-    // invoke installed fetch; because of toStandardFetch, baseFetch recei[ves a Request
-    await cfg.fetch("https://api.example.com/resource")
+    // invoke installed fetch; baseFetch receives a Request
+    await cfg.fetch(new Request("https://api.example.com/resource"))
     expect(baseFetch).toHaveBeenCalledTimes(1)
     const req = (baseFetch as any).mock.calls[0][0] as Request
     expect(req instanceof Request).toBe(true)
@@ -95,9 +95,9 @@ describe("configureClient (singleton)", () => {
     )
 
     const cfg = (singleton.setConfig as any).mock.calls[0][0]
-    await cfg.fetch("https://api.example.com/resource", { headers: { x: "y" } })
+    await cfg.fetch(new Request("https://api.example.com/resource", { headers: { x: "y" } }))
 
-    // baseFetch is called with a Request (toStandardFetch)
+    // baseFetch is called with a Request
     const req = (baseFetch as any).mock.calls[0][0] as Request
     expect(req.headers.get("authorization")).toBeNull()
     expect(req.headers.get("x")).toBe("y")
@@ -151,8 +151,7 @@ describe("createShopperClient (factory)", () => {
     expect(typeof mainClientConfig.fetch).toBe("function")
 
     // Test the auth-wrapped fetch - this should trigger token fetching
-    // Use string URL like the first test does
-    await mainClientConfig.fetch("https://api.example.com/something")
+    await mainClientConfig.fetch(new Request("https://api.example.com/something"))
     
     // Auth should have been applied
     expect(baseFetch).toHaveBeenCalled()
@@ -161,7 +160,7 @@ describe("createShopperClient (factory)", () => {
     expect(req.headers.get("authorization")).toMatch(/^Bearer /)
     
     // Test that user headers are preserved
-    await mainClientConfig.fetch("https://api.example.com/with-headers", { headers: { "x-two": "2" } })
+    await mainClientConfig.fetch(new Request("https://api.example.com/with-headers", { headers: { "x-two": "2" } }))
     const req2 = (baseFetch as any).mock.calls[1][0] as Request
     expect(req2.headers.get("x-two")).toBe("2")
     expect(req2.headers.get("authorization")).toMatch(/^Bearer /)

--- a/packages/sdks/shopper/src/auth/configure-client.ts
+++ b/packages/sdks/shopper/src/auth/configure-client.ts
@@ -31,7 +31,7 @@ export type AuthOptions = {
   /**
    * Cookie options when storage = "cookie".
    */
-  cookie?: Parameters<typeof cookieAdapter>[1]
+  cookie?: Omit<Parameters<typeof cookieAdapter>[0], "name">
   /**
    * Wrap the provided `fetch` with auth logic (attach Bearer + retry once on 401). Defaults to true.
    */
@@ -43,9 +43,9 @@ function resolveStorage(
   cookie?: AuthOptions["cookie"],
 ): StorageAdapter {
   return storage === "cookie"
-    ? cookieAdapter("ep_shopper_access", { sameSite: "Lax", ...cookie })
+    ? cookieAdapter({ sameSite: "Lax", ...cookie })
     : storage === "localStorage" || !storage
-    ? localStorageAdapter("ep.shopper.access")
+    ? localStorageAdapter()
     : storage
 }
 

--- a/packages/sdks/shopper/src/auth/configure-client.ts
+++ b/packages/sdks/shopper/src/auth/configure-client.ts
@@ -1,0 +1,166 @@
+import { client as singleton } from "../client/sdk.gen"
+import { createClient as sdkCreateClient } from "@hey-api/client-fetch"
+import { createAuth, type TokenProvider } from "./kit"
+import {
+  localStorageAdapter,
+  cookieAdapter,
+  type StorageAdapter,
+} from "./storage"
+import { makeAuthFetch } from "./make-auth-fetch"
+import { makeImplicitTokenProviderWithFreshSdk } from "./token-providers"
+
+// Exact types from the generated/heyapi surface
+type HeyApiConfig = Parameters<typeof singleton.setConfig>[0]
+type HeyApiCreateConfig = Parameters<typeof sdkCreateClient>[0]
+
+export type AuthOptions = {
+  /**
+   * Elastic Path key (Client ID) for your store. Required.
+   */
+  clientId: string
+  /**
+   * Optional: supply your own provider. If omitted, we call the SDK’s OAuth op via a fresh bare client.
+   */
+  tokenProvider?: TokenProvider
+  /**
+   * Where to store the access token. Defaults to localStorage; use "cookie" for JS-readable cookies.
+   */
+  storage?: "localStorage" | "cookie" | StorageAdapter
+  /**
+   * Cookie options when storage = "cookie".
+   */
+  cookie?: Parameters<typeof cookieAdapter>[1]
+  /**
+   * Wrap the provided `fetch` with auth logic (attach Bearer + retry once on 401). Defaults to true.
+   */
+  wrapUserFetch?: boolean
+}
+
+/* ------------------------------------------------------------
+   Helpers
+------------------------------------------------------------ */
+
+function resolveStorage(
+  storage: AuthOptions["storage"],
+  cookie?: AuthOptions["cookie"],
+): StorageAdapter {
+  return storage === "cookie"
+    ? cookieAdapter("ep_shopper_access", { sameSite: "Lax", ...cookie })
+    : storage === "localStorage" || !storage
+    ? localStorageAdapter("ep.shopper.access")
+    : storage
+}
+
+/**
+ * Normalize either (req: Request) => Promise<Response>
+ * or (input, init?) => Promise<Response> into standard fetch shape.
+ */
+function toStandardFetch(userFetch?: unknown): typeof fetch {
+  if (!userFetch) {
+    return (input: RequestInfo | URL, init?: RequestInit) => fetch(input, init)
+  }
+  return (input: RequestInfo | URL, init?: RequestInit) => {
+    const req = input instanceof Request ? input : new Request(input, init)
+    // Many heyapi configs accept (req: Request). Standard fetch also accepts a Request as the first arg.
+    // Call with Request to satisfy both shapes.
+    return (userFetch as (req: Request) => Promise<Response>)(req)
+  }
+}
+
+function normalizeHeaders(
+  headers: HeadersInit | Record<string, unknown> | undefined,
+): HeadersInit | undefined {
+  if (!headers) return undefined
+  if (headers instanceof Headers || Array.isArray(headers)) return headers
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(headers)) out[k] = String(v)
+  return out
+}
+
+function resolveFetch(
+  auth: ReturnType<typeof createAuth>,
+  userFetch: unknown,
+  wrapUserFetch: boolean | undefined,
+) {
+  const baseStd: typeof fetch = toStandardFetch(userFetch) // unified shape
+  const authedStd = makeAuthFetch(auth, baseStd, {
+    isAuthRequest: (u) => u.includes("/oauth/"),
+  })
+  // If user opts out, still return a standard-shaped fetch
+  return wrapUserFetch !== false ? authedStd : baseStd
+}
+
+/* ------------------------------------------------------------
+   Public API
+------------------------------------------------------------ */
+
+/**
+ * Configure the generated singleton client using the *exact* Hey API config,
+ * plus separate Auth options.
+ */
+export function configureClient(config: HeyApiConfig, authOpts: AuthOptions) {
+  const { fetch: userFetch, headers, ...rest } = config
+
+  // Some codegens mark baseUrl optional in the type; we rely on what the caller passed.
+  const baseUrl = (config as any).baseUrl as string
+
+  const storageImpl = resolveStorage(authOpts.storage, authOpts.cookie)
+  const headersNorm = normalizeHeaders(headers)
+
+  const provider: TokenProvider =
+    authOpts.tokenProvider ??
+    makeImplicitTokenProviderWithFreshSdk({
+      baseUrl: String(baseUrl),
+      clientId: authOpts.clientId,
+      fetch: userFetch as any, // unwrapped
+      headers: headersNorm,
+    })
+
+  const auth = createAuth(storageImpl, provider)
+  const finalFetch = resolveFetch(auth, userFetch, authOpts.wrapUserFetch)
+
+  singleton.setConfig({
+    ...rest,
+    baseUrl,
+    headers: headersNorm,
+    fetch: finalFetch,
+  })
+
+  return { client: singleton, auth }
+}
+
+/**
+ * Create and return a brand-new client instance (does not mutate the singleton),
+ * using the *exact* Hey API createClient config + separate Auth options.
+ */
+export function createShopperClient<T extends NonNullable<HeyApiCreateConfig>>(
+  config: T,
+  authOpts: AuthOptions,
+) {
+  const { fetch: userFetch, headers, ...rest } = config
+  const baseUrl = (config as any).baseUrl as string
+
+  const storageImpl = resolveStorage(authOpts.storage, authOpts.cookie)
+  const headersNorm = normalizeHeaders(headers)
+
+  const provider: TokenProvider =
+    authOpts.tokenProvider ??
+    makeImplicitTokenProviderWithFreshSdk({
+      baseUrl: String(baseUrl),
+      clientId: authOpts.clientId,
+      fetch: userFetch as any,
+      headers: headersNorm,
+    })
+
+  const auth = createAuth(storageImpl, provider)
+  const finalFetch = resolveFetch(auth, userFetch, authOpts.wrapUserFetch)
+
+  const instance = sdkCreateClient({
+    ...rest,
+    baseUrl,
+    headers: headersNorm,
+    fetch: finalFetch,
+  })
+
+  return { client: instance, auth }
+}

--- a/packages/sdks/shopper/src/auth/kit.test.ts
+++ b/packages/sdks/shopper/src/auth/kit.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { createAuth, type TokenProvider } from "./kit"
+import { memoryAdapter } from "./storage"
+import { makeJwtExpIn } from "../test/utils"
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe("createAuth", () => {
+  it("returns existing valid token without calling provider", async () => {
+    const t = makeJwtExpIn(3600)
+    const storage = memoryAdapter(t)
+    const provider: TokenProvider = vi.fn()
+    const auth = createAuth(storage, provider)
+    await expect(auth.getValidAccessToken()).resolves.toBe(t)
+    expect(provider).not.toHaveBeenCalled()
+  })
+
+  it("calls provider when expired and stores token", async () => {
+    const expired = makeJwtExpIn(-10)
+    const storage = memoryAdapter(expired)
+    const newTok = makeJwtExpIn(1200)
+    const provider: TokenProvider = vi
+      .fn()
+      .mockResolvedValue({ access_token: newTok, expires_in: 1200 })
+    const auth = createAuth(storage, provider)
+    const got = await auth.getValidAccessToken()
+    expect(got).toBe(newTok)
+  })
+
+  it("single-flight refresh across concurrent callers", async () => {
+    const storage = memoryAdapter(makeJwtExpIn(-1))
+    const provider = vi
+      .fn()
+      .mockResolvedValue({ access_token: makeJwtExpIn(1000) })
+    const auth = createAuth(storage, provider)
+    const [a, b, c] = await Promise.all([
+      auth.getValidAccessToken(),
+      auth.getValidAccessToken(),
+      auth.getValidAccessToken(),
+    ])
+    expect(a).toBe(b)
+    expect(b).toBe(c)
+    expect(provider).toHaveBeenCalledTimes(1)
+  })
+
+  it("uses JWT exp over expires_in", async () => {
+    const storage = memoryAdapter(makeJwtExpIn(-1))
+    // JWT with long exp, but small expires_in -> should still accept by JWT exp
+    const long = makeJwtExpIn(5000)
+    const provider = vi
+      .fn()
+      .mockResolvedValue({ access_token: long, expires_in: 5 })
+    const auth = createAuth(storage, provider)
+    const got = await auth.getValidAccessToken()
+    expect(got).toBe(long)
+  })
+
+  it("clear() drops token", async () => {
+    const t = makeJwtExpIn(100)
+    const storage = memoryAdapter(t)
+    const provider = vi
+      .fn()
+      .mockResolvedValue({ access_token: makeJwtExpIn(100) })
+    const auth = createAuth(storage, provider)
+    expect(await auth.getValidAccessToken()).toBe(t)
+    auth.clear()
+    // next call needs provider
+    await auth.getValidAccessToken()
+    expect(provider).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/sdks/shopper/src/auth/kit.ts
+++ b/packages/sdks/shopper/src/auth/kit.ts
@@ -1,0 +1,76 @@
+import { AccessTokenResponse } from "../client"
+
+export type TokenProvider = (opts: {
+  current?: string
+}) => Promise<AccessTokenResponse>
+
+export function createAuth(
+  storage: import("./storage").StorageAdapter,
+  tokenProvider: TokenProvider,
+  leewaySec = 60,
+) {
+  let accessToken = storage.get()
+  let expiresAt = decodeExp(accessToken) ?? 0
+  let refreshing: Promise<string> | undefined
+
+  // Optional cross-tab sync (localStorage adapter implements subscribe)
+  storage.subscribe?.(() => {
+    accessToken = storage.get()
+    expiresAt = decodeExp(accessToken) ?? 0
+  })
+
+  function decodeExp(jwt?: string): number | undefined {
+    if (!jwt) return undefined
+    try {
+      const payload = JSON.parse(atob(jwt.split(".")[1]))
+      return typeof payload?.exp === "number" ? payload.exp : undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  function isExpired(): boolean {
+    if (!accessToken) return true
+    const exp = expiresAt
+    if (!exp) return true
+    const now = Math.floor(Date.now() / 1000)
+    return now >= exp - leewaySec
+  }
+
+  async function refresh(): Promise<string> {
+    if (refreshing) return refreshing
+    refreshing = (async () => {
+      const res = await tokenProvider({ current: accessToken })
+      accessToken = res.access_token
+      expiresAt =
+        decodeExp(accessToken) ??
+        Math.floor(Date.now() / 1000) + (res.expires_in ?? 300)
+      storage.set(accessToken)
+      return accessToken!
+    })()
+    try {
+      return await refreshing
+    } finally {
+      refreshing = undefined
+    }
+  }
+
+  async function getValidAccessToken(): Promise<string> {
+    if (accessToken && !isExpired()) return accessToken
+    return refresh()
+  }
+
+  function clear() {
+    accessToken = undefined
+    expiresAt = 0
+    storage.set(undefined)
+  }
+
+  function getSnapshot() {
+    return accessToken
+  }
+
+  return { getValidAccessToken, refresh, clear, getSnapshot }
+}
+
+export type Auth = ReturnType<typeof createAuth>

--- a/packages/sdks/shopper/src/auth/make-auth-fetch.test.ts
+++ b/packages/sdks/shopper/src/auth/make-auth-fetch.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { makeAuthFetch } from "./make-auth-fetch"
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+function ok(body = "ok", init: Partial<ResponseInit> = {}) {
+  return new Response(body, { status: 200, ...init })
+}
+function unauthorized() {
+  return new Response("nope", { status: 401 })
+}
+
+describe("makeAuthFetch", () => {
+  const fakeAuth = (opts?: {
+    token?: string
+    refreshed?: string
+    refreshFails?: boolean
+  }) => {
+    const api = {
+      getValidAccessToken: vi.fn().mockResolvedValue(opts?.token ?? "t1"),
+      refresh: opts?.refreshFails
+        ? vi.fn().mockRejectedValue(new Error("fail"))
+        : vi.fn().mockResolvedValue(opts?.refreshed ?? "t2"),
+      clear: vi.fn(),
+    }
+    return api
+  }
+
+  it("attaches Authorization when missing", async () => {
+    const base = vi.fn().mockResolvedValue(ok())
+    const auth = fakeAuth({ token: "abc" })
+    const f = makeAuthFetch(auth as any, base)
+    await f("/resource")
+    const [input, init] = base.mock.calls[0]
+    const h = new Headers((init as RequestInit).headers)
+    expect(h.get("authorization")).toBe("Bearer abc")
+  })
+
+  it("does not overwrite pre-set Authorization", async () => {
+    const base = vi.fn().mockResolvedValue(ok())
+    const auth = fakeAuth({ token: "abc" })
+    const f = makeAuthFetch(auth as any, base)
+    await f("/resource", { headers: { Authorization: "Bearer preset" } })
+    const [, init] = base.mock.calls[0]
+    const h = new Headers((init as RequestInit).headers)
+    expect(h.get("authorization")).toBe("Bearer preset")
+  })
+
+  it("retries once on 401 after refresh", async () => {
+    const base = vi
+      .fn()
+      .mockResolvedValueOnce(unauthorized())
+      .mockResolvedValueOnce(ok("retried"))
+    const auth = fakeAuth({ token: "old", refreshed: "new" })
+    const f = makeAuthFetch(auth as any, base)
+    const res = await f("/res")
+    expect(await res.text()).toBe("retried")
+    expect(auth.refresh).toHaveBeenCalledTimes(1)
+    const [, init1] = base.mock.calls[0]
+    const [, init2] = base.mock.calls[1]
+    expect(new Headers((init1 as any).headers).get("authorization")).toBe(
+      "Bearer old",
+    )
+    expect(new Headers((init2 as any).headers).get("authorization")).toBe(
+      "Bearer new",
+    )
+  })
+
+  it("bubbles 401 when refresh fails", async () => {
+    const base = vi.fn().mockResolvedValue(unauthorized())
+    const auth = fakeAuth({ refreshFails: true })
+    const f = makeAuthFetch(auth as any, base)
+    const res = await f("/res")
+    expect(res.status).toBe(401)
+    expect(auth.clear).toHaveBeenCalledTimes(1)
+  })
+
+  it("skips oauth endpoints entirely", async () => {
+    const base = vi.fn().mockResolvedValue(ok())
+    const auth = fakeAuth({ token: "zzz" })
+    const f = makeAuthFetch(auth as any, base, {
+      isAuthRequest: (u) => u.includes("/oauth/"),
+    })
+    await f("/oauth/access_token")
+    expect(auth.getValidAccessToken).not.toHaveBeenCalled()
+    expect(base).toHaveBeenCalledTimes(1)
+    const [, init] = base.mock.calls[0]
+    const h = new Headers((init as RequestInit).headers)
+    expect(h.get("authorization")).toBeNull()
+  })
+})

--- a/packages/sdks/shopper/src/auth/make-auth-fetch.ts
+++ b/packages/sdks/shopper/src/auth/make-auth-fetch.ts
@@ -1,4 +1,5 @@
 import type { Auth } from "./kit"
+import { Config } from "@hey-api/client-fetch"
 
 /**
  * Wrap a base fetch (default: global fetch) with:
@@ -8,36 +9,38 @@ import type { Auth } from "./kit"
  */
 export function makeAuthFetch(
   auth: Auth,
-  baseFetch: typeof fetch = fetch,
+  baseFetch?: Config["fetch"],
   opts?: { isAuthRequest?: (url: string, init: RequestInit) => boolean },
-): typeof fetch {
-  return async (input: RequestInfo | URL, init: RequestInit = {}) => {
-    const url =
-      typeof input === "string"
-        ? input
-        : input instanceof URL
-        ? input.toString()
-        : (input as Request).url
+): Config["fetch"] {
+  // Default to global fetch if not provided
+  const fetchFn = baseFetch || ((request: Request) => globalThis.fetch(request))
+
+  return async (request: Request) => {
+    const url = request.url
 
     // Never intercept OAuth calls (avoid loops)
-    if (opts?.isAuthRequest?.(url, init) ?? url.includes("/oauth/")) {
-      return baseFetch(input, init)
+    if (opts?.isAuthRequest?.(url, {}) ?? url.includes("/oauth/")) {
+      return fetchFn(request)
     }
 
-    // Attach bearer
+    // Clone the request to modify headers
     const token = await auth.getValidAccessToken()
-    const h1 = new Headers(init.headers)
+    const h1 = new Headers(request.headers)
     if (!h1.has("Authorization")) h1.set("Authorization", `Bearer ${token}`)
-    let res = await baseFetch(input, { ...init, headers: h1 })
+
+    const authedRequest = new Request(request, { headers: h1 })
+    let res = await fetchFn(authedRequest)
 
     if (res.status !== 401) return res
 
     // Retry once after forced re-auth
     try {
       const fresh = await auth.refresh()
-      const h2 = new Headers(init.headers)
+      const h2 = new Headers(request.headers)
       if (!h2.has("Authorization")) h2.set("Authorization", `Bearer ${fresh}`)
-      return baseFetch(input, { ...init, headers: h2 })
+
+      const retryRequest = new Request(request, { headers: h2 })
+      return fetchFn(retryRequest)
     } catch {
       auth.clear()
       return res // bubble the 401

--- a/packages/sdks/shopper/src/auth/make-auth-fetch.ts
+++ b/packages/sdks/shopper/src/auth/make-auth-fetch.ts
@@ -1,0 +1,46 @@
+import type { Auth } from "./kit"
+
+/**
+ * Wrap a base fetch (default: global fetch) with:
+ *  - Authorization: Bearer <token> (unless caller already set it)
+ *  - single forced re-auth + one retry on 401
+ *  - optional skip for OAuth endpoints
+ */
+export function makeAuthFetch(
+  auth: Auth,
+  baseFetch: typeof fetch = fetch,
+  opts?: { isAuthRequest?: (url: string, init: RequestInit) => boolean },
+): typeof fetch {
+  return async (input: RequestInfo | URL, init: RequestInit = {}) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : (input as Request).url
+
+    // Never intercept OAuth calls (avoid loops)
+    if (opts?.isAuthRequest?.(url, init) ?? url.includes("/oauth/")) {
+      return baseFetch(input, init)
+    }
+
+    // Attach bearer
+    const token = await auth.getValidAccessToken()
+    const h1 = new Headers(init.headers)
+    if (!h1.has("Authorization")) h1.set("Authorization", `Bearer ${token}`)
+    let res = await baseFetch(input, { ...init, headers: h1 })
+
+    if (res.status !== 401) return res
+
+    // Retry once after forced re-auth
+    try {
+      const fresh = await auth.refresh()
+      const h2 = new Headers(init.headers)
+      if (!h2.has("Authorization")) h2.set("Authorization", `Bearer ${fresh}`)
+      return baseFetch(input, { ...init, headers: h2 })
+    } catch {
+      auth.clear()
+      return res // bubble the 401
+    }
+  }
+}

--- a/packages/sdks/shopper/src/auth/storage.test.ts
+++ b/packages/sdks/shopper/src/auth/storage.test.ts
@@ -28,12 +28,21 @@ describe("localStorageAdapter", () => {
 
 describe("cookieAdapter", () => {
   it("get/set/remove round-trips", () => {
-    const a = cookieAdapter("cookie_k", { path: "/", sameSite: "Lax" })
+    const a = cookieAdapter({ name: "cookie_k", path: "/", sameSite: "Lax" })
     expect(a.get()).toBeUndefined()
     a.set("CT")
     expect(a.get()).toBe("CT")
     a.set(undefined)
     expect(a.get()).toBeUndefined()
+  })
+  
+  it("uses default name when not provided", () => {
+    const a = cookieAdapter({ sameSite: "Strict" })
+    // Test still works with default name
+    expect(a.get()).toBeUndefined()
+    a.set("DEFAULT")
+    expect(a.get()).toBe("DEFAULT")
+    a.set(undefined)
   })
 })
 

--- a/packages/sdks/shopper/src/auth/storage.test.ts
+++ b/packages/sdks/shopper/src/auth/storage.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { localStorageAdapter, cookieAdapter, memoryAdapter } from "./storage"
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe("localStorageAdapter", () => {
+  it("get/set/remove round-trips", () => {
+    const a = localStorageAdapter("k")
+    expect(a.get()).toBeUndefined()
+    a.set("T")
+    expect(a.get()).toBe("T")
+    a.set(undefined)
+    expect(a.get()).toBeUndefined()
+  })
+
+  it("subscribe triggers on storage event", () => {
+    const a = localStorageAdapter("k2")
+    const fn = vi.fn()
+    const unsub = a.subscribe!(fn)
+    localStorage.setItem("k2", "X")
+    window.dispatchEvent(new StorageEvent("storage", { key: "k2" }))
+    expect(fn).toHaveBeenCalledTimes(1)
+    unsub()
+  })
+})
+
+describe("cookieAdapter", () => {
+  it("get/set/remove round-trips", () => {
+    const a = cookieAdapter("cookie_k", { path: "/", sameSite: "Lax" })
+    expect(a.get()).toBeUndefined()
+    a.set("CT")
+    expect(a.get()).toBe("CT")
+    a.set(undefined)
+    expect(a.get()).toBeUndefined()
+  })
+})
+
+describe("memoryAdapter", () => {
+  it("stores in memory and notifies subscribers", () => {
+    const a = memoryAdapter()
+    const fn = vi.fn()
+    const unsub = a.subscribe!(fn)
+    a.set("M")
+    expect(a.get()).toBe("M")
+    expect(fn).toHaveBeenCalledTimes(1)
+    unsub()
+  })
+})

--- a/packages/sdks/shopper/src/auth/storage.ts
+++ b/packages/sdks/shopper/src/auth/storage.ts
@@ -59,15 +59,17 @@ export function localStorageAdapter(
 
 /** JS-readable cookie adapter (NOT httpOnly). For httpOnly cookies, keep access token here only. */
 export function cookieAdapter(
-  name = CREDENTIALS_STORAGE_KEY,
-  attrs: Partial<{
-    path: string
-    domain: string
-    sameSite: "Lax" | "Strict" | "None"
-    secure: boolean
-    maxAge: number // seconds
-  }> = { path: "/", sameSite: "Lax" },
+  options: {
+    name?: string
+    path?: string
+    domain?: string
+    sameSite?: "Lax" | "Strict" | "None"
+    secure?: boolean
+    maxAge?: number // seconds
+  } = {},
 ): StorageAdapter {
+  const { name = CREDENTIALS_STORAGE_KEY, ...attrs } = options
+  const { path = "/", sameSite = "Lax" } = attrs
   const read = () => {
     if (typeof document === "undefined") return undefined
     const raw = document.cookie
@@ -84,8 +86,8 @@ export function cookieAdapter(
   const write = (v: string) => {
     if (typeof document === "undefined") return
     let s =
-      `${name}=${encodeURIComponent(v)}; Path=${attrs.path ?? "/"}` +
-      `; SameSite=${attrs.sameSite ?? "Lax"}`
+      `${name}=${encodeURIComponent(v)}; Path=${path}` +
+      `; SameSite=${sameSite}`
     if (attrs.domain) s += `; Domain=${attrs.domain}`
     if (attrs.secure) s += `; Secure`
     if (attrs.maxAge) s += `; Max-Age=${attrs.maxAge}`
@@ -94,7 +96,7 @@ export function cookieAdapter(
 
   const clear = () => {
     if (typeof document === "undefined") return
-    document.cookie = `${name}=; Max-Age=0; Path=${attrs.path ?? "/"}`
+    document.cookie = `${name}=; Max-Age=0; Path=${path}`
   }
 
   return {

--- a/packages/sdks/shopper/src/auth/storage.ts
+++ b/packages/sdks/shopper/src/auth/storage.ts
@@ -1,0 +1,122 @@
+import { CREDENTIALS_STORAGE_KEY } from "../constants/credentials"
+
+export interface StorageAdapter {
+  /** Return the current access token (string) or undefined if none. */
+  get(): string | undefined
+  /** Persist or remove the access token. */
+  set(token?: string): void
+  /** Optional: subscribe to external changes (e.g., other tabs). Returns an unsubscribe. */
+  subscribe?(cb: () => void): () => void
+}
+
+/** Safe localStorage adapter with cross-tab sync (via 'storage' event). */
+export function localStorageAdapter(
+  key = CREDENTIALS_STORAGE_KEY,
+): StorageAdapter {
+  const subs = new Set<() => void>()
+
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === key) subs.forEach((fn) => fn())
+  }
+
+  const safeGet = () => {
+    try {
+      if (typeof window === "undefined" || !("localStorage" in window))
+        return undefined
+      return window.localStorage.getItem(key) ?? undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  const safeSet = (t?: string) => {
+    try {
+      if (typeof window === "undefined" || !("localStorage" in window)) return
+      if (!t) window.localStorage.removeItem(key)
+      else window.localStorage.setItem(key, t)
+    } catch {
+      /* no-op */
+    }
+  }
+
+  return {
+    get: safeGet,
+    set: safeSet,
+    subscribe(cb) {
+      subs.add(cb)
+      if (typeof window !== "undefined") {
+        window.addEventListener("storage", onStorage)
+      }
+      return () => {
+        subs.delete(cb)
+        if (!subs.size && typeof window !== "undefined") {
+          window.removeEventListener("storage", onStorage)
+        }
+      }
+    },
+  }
+}
+
+/** JS-readable cookie adapter (NOT httpOnly). For httpOnly cookies, keep access token here only. */
+export function cookieAdapter(
+  name = CREDENTIALS_STORAGE_KEY,
+  attrs: Partial<{
+    path: string
+    domain: string
+    sameSite: "Lax" | "Strict" | "None"
+    secure: boolean
+    maxAge: number // seconds
+  }> = { path: "/", sameSite: "Lax" },
+): StorageAdapter {
+  const read = () => {
+    if (typeof document === "undefined") return undefined
+    const raw = document.cookie
+      .split("; ")
+      .find((c) => c.startsWith(name + "="))
+    if (!raw) return undefined
+    try {
+      return decodeURIComponent(raw.split("=").slice(1).join("="))
+    } catch {
+      return raw.split("=").slice(1).join("=")
+    }
+  }
+
+  const write = (v: string) => {
+    if (typeof document === "undefined") return
+    let s =
+      `${name}=${encodeURIComponent(v)}; Path=${attrs.path ?? "/"}` +
+      `; SameSite=${attrs.sameSite ?? "Lax"}`
+    if (attrs.domain) s += `; Domain=${attrs.domain}`
+    if (attrs.secure) s += `; Secure`
+    if (attrs.maxAge) s += `; Max-Age=${attrs.maxAge}`
+    document.cookie = s
+  }
+
+  const clear = () => {
+    if (typeof document === "undefined") return
+    document.cookie = `${name}=; Max-Age=0; Path=${attrs.path ?? "/"}`
+  }
+
+  return {
+    get: read,
+    set: (t) => (t ? write(t) : clear()),
+    // No reliable cookie change event across tabs; omit subscribe
+  }
+}
+
+/** In-memory adapter (useful for SSR/tests). */
+export function memoryAdapter(initial?: string): StorageAdapter {
+  let value = initial
+  const subs = new Set<() => void>()
+  return {
+    get: () => value,
+    set: (t) => {
+      value = t
+      subs.forEach((fn) => fn())
+    },
+    subscribe(cb) {
+      subs.add(cb)
+      return () => subs.delete(cb)
+    },
+  }
+}

--- a/packages/sdks/shopper/src/auth/token-providers.test.ts
+++ b/packages/sdks/shopper/src/auth/token-providers.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { asAny } from "../test/utils"
+
+// Mock SDK modules before imports
+vi.mock("../client/sdk.gen", () => ({
+  client: {
+    setConfig: vi.fn(),
+    getConfig: vi.fn().mockReturnValue({
+      baseUrl: "https://api.example.com",
+      headers: {},
+      fetch: vi.fn(),
+    }),
+  },
+  createAnAccessToken: vi.fn(),
+}))
+
+vi.mock("@hey-api/client-fetch", () => ({
+  createClient: vi.fn((config?: any) => ({
+    ...config,
+    getConfig: vi.fn().mockReturnValue(config || {}),
+  })),
+  createConfig: vi.fn((cfg?: any) => cfg ?? {}),
+}))
+
+import {
+  makeImplicitTokenProviderWithFreshSdk,
+  makeImplicitTokenProviderCachedBare,
+} from "./token-providers"
+import { createClient } from "@hey-api/client-fetch"
+import { createAnAccessToken } from "../client/sdk.gen"
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe("makeImplicitTokenProviderWithFreshSdk", () => {
+  it("builds a fresh bare client and calls createAnAccessToken with client + body", async () => {
+    // Arrange bare client and op
+    const bare = { __tag: "bare" }
+    asAny(createClient).mockReturnValue(bare)
+
+    asAny(createAnAccessToken).mockResolvedValue({
+      data: { access_token: "TOK", expires_in: 3600, token_type: "Bearer" },
+      error: undefined,
+    })
+
+    const provider = makeImplicitTokenProviderWithFreshSdk({
+      baseUrl: "https://api.example.com",
+      clientId: "CID",
+      fetch: vi.fn(), // pass-through fetch should be used to build the bare client
+      headers: { "x-a": "b" },
+    })
+
+    // Act
+    const res = await provider({})
+
+    // Assert createClient invocation
+    expect(createClient).toHaveBeenCalledWith({
+      baseUrl: "https://api.example.com",
+      fetch: expect.any(Function),
+      headers: { "x-a": "b" },
+    })
+
+    // Assert createAnAccessToken called with that client + body
+    expect(createAnAccessToken).toHaveBeenCalledWith({
+      client: bare,
+      body: { grant_type: "implicit", client_id: "CID" },
+    })
+
+    // Result mapping
+    expect(res).toEqual({
+      access_token: "TOK",
+      expires_in: 3600,
+      expires: undefined,
+      token_type: "Bearer",
+    })
+  })
+
+  it("throws when the operation returns an error", async () => {
+    const bare = { __tag: "bare" }
+    asAny(createClient).mockReturnValue(bare)
+    asAny(createAnAccessToken).mockResolvedValue({
+      data: undefined,
+      error: { type: "unauthorized" },
+    })
+
+    const provider = makeImplicitTokenProviderWithFreshSdk({
+      baseUrl: "https://api.example.com",
+      clientId: "CID",
+    })
+
+    await expect(provider({})).rejects.toThrow(
+      "makeImplicitTokenProviderWithFreshSdk: Failed to get access token",
+    )
+  })
+
+  it("handles responses where data is present but no expires fields", async () => {
+    const bare = { __tag: "bare" }
+    asAny(createClient).mockReturnValue(bare)
+    asAny(createAnAccessToken).mockResolvedValue({
+      data: { access_token: "TOK2" },
+      error: undefined,
+    })
+
+    const provider = makeImplicitTokenProviderWithFreshSdk({
+      baseUrl: "https://api.example.com",
+      clientId: "CID",
+    })
+
+    const res = await provider({})
+    expect(res).toEqual({
+      access_token: "TOK2",
+      expires_in: undefined,
+      expires: undefined,
+      token_type: undefined,
+    })
+  })
+})
+
+describe("makeImplicitTokenProviderCachedBare", () => {
+  it("reuses the same bare client across calls", async () => {
+    const bare = { __tag: "bare" }
+    asAny(createClient).mockReturnValue(bare)
+
+    asAny(createAnAccessToken)
+      .mockResolvedValueOnce({
+        data: { access_token: "A", expires_in: 60 },
+        error: undefined,
+      })
+      .mockResolvedValueOnce({
+        data: { access_token: "B", expires_in: 60 },
+        error: undefined,
+      })
+
+    const provider = makeImplicitTokenProviderCachedBare({
+      baseUrl: "https://api.example.com",
+      clientId: "CID",
+      headers: { h: "v" },
+    })
+
+    const r1 = await provider({})
+    const r2 = await provider({})
+
+    // createClient called only once
+    expect(createClient).toHaveBeenCalledTimes(1)
+
+    // both calls used the same client instance
+    expect(createAnAccessToken).toHaveBeenNthCalledWith(1, {
+      client: bare,
+      body: { grant_type: "implicit", client_id: "CID" },
+    })
+    expect(createAnAccessToken).toHaveBeenNthCalledWith(2, {
+      client: bare,
+      body: { grant_type: "implicit", client_id: "CID" },
+    })
+
+    expect(r1.access_token).toBe("A")
+    expect(r2.access_token).toBe("B")
+  })
+
+  it("throws when the cached op returns an error", async () => {
+    const bare = { __tag: "bare" }
+    asAny(createClient).mockReturnValue(bare)
+    asAny(createAnAccessToken).mockResolvedValue({
+      data: undefined,
+      error: { message: "boom" },
+    })
+
+    const provider = makeImplicitTokenProviderCachedBare({
+      baseUrl: "https://api.example.com",
+      clientId: "CID",
+    })
+
+    await expect(provider({})).rejects.toThrow(
+      "makeImplicitTokenProviderCachedBare: Failed to get access token",
+    )
+  })
+})

--- a/packages/sdks/shopper/src/auth/token-providers.ts
+++ b/packages/sdks/shopper/src/auth/token-providers.ts
@@ -1,5 +1,5 @@
 import type { TokenProvider } from "./kit"
-import { createClient } from "@hey-api/client-fetch"
+import { type Config, createClient } from "@hey-api/client-fetch"
 import { createAnAccessToken } from "../client/sdk.gen"
 
 /**
@@ -10,14 +10,14 @@ import { createAnAccessToken } from "../client/sdk.gen"
 export function makeImplicitTokenProviderWithFreshSdk(opts: {
   baseUrl: string
   clientId: string
-  fetch?: typeof fetch // user-supplied fetch (unwrapped)
+  fetch?: Config["fetch"]
   headers?: HeadersInit | Record<string, string>
   // If your SDK needs any other createClient options, add them here and pass through.
 }): TokenProvider {
   return async () => {
     const bare = createClient({
       baseUrl: opts.baseUrl,
-      fetch: opts.fetch, // IMPORTANT: unwrapped
+      fetch: opts.fetch,
       headers: opts.headers,
     })
 
@@ -50,7 +50,7 @@ export function makeImplicitTokenProviderWithFreshSdk(opts: {
 export function makeImplicitTokenProviderCachedBare(opts: {
   baseUrl: string
   clientId: string
-  fetch?: typeof fetch
+  fetch?: Config["fetch"]
   headers?: HeadersInit | Record<string, string>
 }): TokenProvider {
   let bare = createClient({

--- a/packages/sdks/shopper/src/auth/token-providers.ts
+++ b/packages/sdks/shopper/src/auth/token-providers.ts
@@ -1,0 +1,82 @@
+import type { TokenProvider } from "./kit"
+import { createClient } from "@hey-api/client-fetch"
+import { createAnAccessToken } from "../client/sdk.gen"
+
+/**
+ * Fresh-instance implicit token provider.
+ * Always constructs a new, BARE sdk client (no auth wrapper, no interceptors) and calls the OAuth op.
+ * This is loop-proof because it never uses the authed client.
+ */
+export function makeImplicitTokenProviderWithFreshSdk(opts: {
+  baseUrl: string
+  clientId: string
+  fetch?: typeof fetch // user-supplied fetch (unwrapped)
+  headers?: HeadersInit | Record<string, string>
+  // If your SDK needs any other createClient options, add them here and pass through.
+}): TokenProvider {
+  return async () => {
+    const bare = createClient({
+      baseUrl: opts.baseUrl,
+      fetch: opts.fetch, // IMPORTANT: unwrapped
+      headers: opts.headers,
+    })
+
+    const resp = await createAnAccessToken({
+      client: bare,
+      body: { grant_type: "implicit", client_id: opts.clientId },
+    })
+
+    if (resp.error) {
+      throw new Error(
+        "makeImplicitTokenProviderWithFreshSdk: Failed to get access token",
+      )
+    }
+
+    const x = resp.data
+
+    return {
+      access_token: x.access_token,
+      expires_in: x.expires_in ?? undefined,
+      expires: x.expires ?? undefined,
+      token_type: x.token_type ?? undefined,
+    }
+  }
+}
+
+/**
+ * Cached bare instance (minor perf win, still loop-proof).
+ * Reuses a single bare client for all OAuth calls.
+ */
+export function makeImplicitTokenProviderCachedBare(opts: {
+  baseUrl: string
+  clientId: string
+  fetch?: typeof fetch
+  headers?: HeadersInit | Record<string, string>
+}): TokenProvider {
+  let bare = createClient({
+    baseUrl: opts.baseUrl,
+    fetch: opts.fetch,
+    headers: opts.headers,
+  })
+
+  return async () => {
+    const resp = await createAnAccessToken({
+      client: bare,
+      body: { grant_type: "implicit", client_id: opts.clientId },
+    })
+
+    if (resp.error) {
+      throw new Error(
+        "makeImplicitTokenProviderCachedBare: Failed to get access token",
+      )
+    }
+
+    const x = resp.data
+    return {
+      access_token: x.access_token,
+      expires_in: x.expires_in,
+      expires: x.expires,
+      token_type: x.token_type,
+    }
+  }
+}

--- a/packages/sdks/shopper/src/index.ts
+++ b/packages/sdks/shopper/src/index.ts
@@ -4,3 +4,5 @@ export { createClient, type Client }
 export { client } from "./client/sdk.gen"
 export { extractProductImage, initializeCart, getCartId } from "./utils"
 export * from "./interceptors"
+
+export { createShopperClient, configureClient } from "./auth/configure-client"

--- a/packages/sdks/shopper/src/test/utils.ts
+++ b/packages/sdks/shopper/src/test/utils.ts
@@ -1,5 +1,3 @@
-import { vi } from "vitest"
-
 /**
  * Helper to craft a JWT with exp in seconds from now
  */

--- a/packages/sdks/shopper/src/test/utils.ts
+++ b/packages/sdks/shopper/src/test/utils.ts
@@ -1,0 +1,21 @@
+import { vi } from "vitest"
+
+/**
+ * Helper to craft a JWT with exp in seconds from now
+ */
+export const makeJwtExpIn = (sec: number) => {
+  const header = { alg: "none", typ: "JWT" }
+  const now = Math.floor(Date.now() / 1000)
+  const payload = { exp: now + sec }
+  const b64 = (o: any) =>
+    btoa(JSON.stringify(o))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "")
+  return `${b64(header)}.${b64(payload)}.`
+}
+
+/**
+ * Type assertion helper for mocks
+ */
+export const asAny = (fn: any): any => fn


### PR DESCRIPTION
  ## Describe your changes
  Add built-in authentication mechanism to the shopper SDK, providing a streamlined auth solution with automatic token management and refresh capabilities.

  ### Key changes:
  - **New auth module**: Added comprehensive authentication helpers including `configureClient`, `createShopperClient`, and auth utilities
  - **Token management**: Automatic token storage, refresh, and expiration handling with support for localStorage and cookie adapters
  - **Simplified integration**: Updated authentication-local-storage example to use new built-in auth, reducing code from ~90 lines to ~36 lines
  - **Storage adapters**: Flexible storage options with localStorage (default), cookies, and custom adapters
  - **Auth interceptor**: Automatic Bearer token attachment and 401 retry logic
  - **Cross-tab sync**: localStorage adapter includes cross-tab synchronization via storage events
  - **Improved API**: Enhanced cookieAdapter to accept options object instead of positional parameters
  - **Comprehensive tests**: Added full test coverage for all auth components

  ### Example usage:
  ```typescript
  configureClient(
    { baseUrl },
    { clientId, storage: "localStorage" }
  )
```
## Issue ticket number and link
n/a
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] I've added a Changeset for my changes - [Click here to learn what changesets are, and how to add one](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)
