### PR TITLE
fix: add build dependency for catalog-search on shopper SDK

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**", "dist-cjs/**", "dist-es/**", "dist-types/**", "build/**"]
     },
+    "@epcc-sdk/sdks-catalog-search#build": {
+      "dependsOn": ["@epcc-sdk/sdks-shopper#build"],
+      "outputs": ["dist/**"]
+    },
     "generate": {
       "outputs": []
     },


### PR DESCRIPTION
## Summary
- Add explicit turborepo task dependency so catalog-search SDK builds after shopper SDK
- Fixes CI failure where catalog-search tries to use bundled spec before it exists

## Problem
The catalog-search SDK depends on `specs/bundled/catalog_search.yaml` which is generated by the shopper SDK's `oas:redocly:bundle` step. Without this dependency, both SDKs build in parallel and catalog-search fails with:
```
ENOENT: no such file or directory, open '.../specs/bundled/catalog_search.yaml'
```

## Solution
Add package-specific task configuration in turbo.json:
```json
"@epcc-sdk/sdks-catalog-search#build": {
  "dependsOn": ["@epcc-sdk/sdks-shopper#build"],
  "outputs": ["dist/**"]
}
```