### PR TITLE
feat(catalog-search-instantsearch-adapter): add `include` support with included-resource merge

### DIFF
--- a/.changeset/catalog-search-include.md
+++ b/.changeset/catalog-search-include.md
@@ -1,0 +1,21 @@
+---
+"@elasticpath/catalog-search-instantsearch-adapter": minor
+---
+
+Add a typed `include` configuration option that forwards to the underlying
+`postMultiSearch` call as the `?include=` URL query parameter. When set, EP
+returns a top-level `included` block alongside hits — letting the consumer
+inline `main_image`, `files`, or `component_products` resources without an
+extra round-trip.
+
+```ts
+new CatalogSearchInstantSearchAdapter({
+  client,
+  additionalSearchParameters: { query_by: "name,description" },
+  include: ["main_image"],
+})
+```
+
+Behaviour is fully backward-compatible: when `include` is unset (or an empty
+array), the adapter does not add a `query` field to the SDK call and the
+request shape is byte-for-byte identical to before.

--- a/.changeset/catalog-search-include.md
+++ b/.changeset/catalog-search-include.md
@@ -4,9 +4,11 @@
 
 Add a typed `include` configuration option that forwards to the underlying
 `postMultiSearch` call as the `?include=` URL query parameter. When set, EP
-returns a top-level `included` block alongside hits — letting the consumer
-inline `main_image`, `files`, or `component_products` resources without an
-extra round-trip.
+returns a top-level `included` block alongside hits, and the adapter resolves
+each hit's `relationships.<resource>.data` references against that block —
+inlining `main_image`, `files`, and/or `component_products` records directly
+onto the hit so consumers can render rich content without a separate
+round-trip per hit (or per page batch via `/catalog/products?filter=in(id,…)`).
 
 ```ts
 new CatalogSearchInstantSearchAdapter({
@@ -14,8 +16,16 @@ new CatalogSearchInstantSearchAdapter({
   additionalSearchParameters: { query_by: "name,description" },
   include: ["main_image"],
 })
+
+// hit.main_image is now the full record with link.href, mime_type, etc.
 ```
+
+`main_image` resolves to a single record; `files` and `component_products`
+resolve to arrays whose order follows the hit's `relationships.<resource>.data`
+order. Missing references are skipped silently. If the server omits the
+`included` block entirely while `include` was requested, the adapter logs a
+single `console.warn` per instance to flag the server-side mismatch.
 
 Behaviour is fully backward-compatible: when `include` is unset (or an empty
 array), the adapter does not add a `query` field to the SDK call and the
-request shape is byte-for-byte identical to before.
+request shape — and resulting hit shape — is byte-for-byte identical to before.

--- a/packages/catalog-search-instantsearch-adapter/README.md
+++ b/packages/catalog-search-instantsearch-adapter/README.md
@@ -164,7 +164,7 @@ const adapter = new CatalogSearchInstantSearchAdapter({
 
 ### Including Related Resources (`include`)
 
-EP's catalog-search response only contains hits and `relationships.<resource>.data.id` references by default — full resource data (image URLs, file metadata, component products) is not inlined. Set `include` to forward the EP `?include=` URL query parameter, and the response will gain a top-level `included` block with the full records keyed by resource type.
+EP's catalog-search response only contains hits and `relationships.<resource>.data.id` references by default — full resource data (image URLs, file metadata, component products) is not inlined. Set `include` to forward the EP `?include=` URL query parameter; the adapter resolves the returned `included` block against each hit and inlines the full records onto the hit.
 
 ```ts
 const adapter = new CatalogSearchInstantSearchAdapter({
@@ -172,9 +172,27 @@ const adapter = new CatalogSearchInstantSearchAdapter({
   additionalSearchParameters: { query_by: "name,description" },
   include: ["main_image"], // also accepts "files", "component_products"
 });
+
+// In a Hits widget:
+const Hit = ({ hit }) => (
+  <article>
+    {hit.main_image && <img src={hit.main_image.link.href} alt={hit.name} />}
+    <h3>{hit.name}</h3>
+  </article>
+);
 ```
 
-The hits keep their `relationships.main_image.data.id` reference; you join against the `included.main_images[]` array (or `included.files[]` / `included.component_products[]`) by `id` to read the full record. Behaviour is back-compat: omit `include` (or pass `[]`) and no `query` field is sent on the SDK call.
+Cardinality follows the EP relationship shape:
+
+| `include` value      | Resolved field on hit | Type                          |
+| -------------------- | --------------------- | ----------------------------- |
+| `"main_image"`       | `hit.main_image`      | single record or `undefined`  |
+| `"files"`            | `hit.files`           | array (in relationships order) |
+| `"component_products"` | `hit.component_products` | array (in relationships order) |
+
+Missing references (a relationship pointing at an id not present in `included`) are skipped silently — the field is left absent rather than set to a partial record. If the server omits the `included` block entirely while `include` was requested, the adapter logs a single `console.warn` per instance to surface the server-side mismatch.
+
+Behaviour is fully back-compat: omit `include` (or pass `[]`) and the adapter neither sends a `query` field nor merges anything onto hits — they retain their original `relationships.<resource>.data` shape.
 
 ## Widget Compatibility
 

--- a/packages/catalog-search-instantsearch-adapter/README.md
+++ b/packages/catalog-search-instantsearch-adapter/README.md
@@ -162,6 +162,20 @@ const adapter = new CatalogSearchInstantSearchAdapter({
 });
 ```
 
+### Including Related Resources (`include`)
+
+EP's catalog-search response only contains hits and `relationships.<resource>.data.id` references by default — full resource data (image URLs, file metadata, component products) is not inlined. Set `include` to forward the EP `?include=` URL query parameter, and the response will gain a top-level `included` block with the full records keyed by resource type.
+
+```ts
+const adapter = new CatalogSearchInstantSearchAdapter({
+  client,
+  additionalSearchParameters: { query_by: "name,description" },
+  include: ["main_image"], // also accepts "files", "component_products"
+});
+```
+
+The hits keep their `relationships.main_image.data.id` reference; you join against the `included.main_images[]` array (or `included.files[]` / `included.component_products[]`) by `id` to read the full record. Behaviour is back-compat: omit `include` (or pass `[]`) and no `query` field is sent on the SDK call.
+
 ## Widget Compatibility
 
 The adapter supports most InstantSearch widgets out of the box:

--- a/packages/catalog-search-instantsearch-adapter/src/CatalogSearchInstantSearchAdapter.test.ts
+++ b/packages/catalog-search-instantsearch-adapter/src/CatalogSearchInstantSearchAdapter.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import CatalogSearchInstantSearchAdapter from "./CatalogSearchInstantSearchAdapter"
+
+// Mock the SDK so we can return a synthetic response shape per test.
+vi.mock("@epcc-sdk/sdks-shopper", () => {
+  return {
+    client: { setConfig: vi.fn() },
+    postMultiSearch: vi.fn(),
+  }
+})
+
+import { postMultiSearch } from "@epcc-sdk/sdks-shopper"
+const postMultiSearchMock = postMultiSearch as unknown as ReturnType<typeof vi.fn>
+
+const buildResponse = (overrides: any = {}) => ({
+  data: {
+    results: [
+      {
+        found: 1,
+        hits: [
+          {
+            document: {
+              id: "p1",
+              relationships: {
+                main_image: { data: { id: "img-1", type: "main_image" } },
+              },
+            },
+            highlights: [],
+            highlight: {},
+          },
+        ],
+        page: 1,
+        request_params: { q: "*", per_page: 10 },
+        search_time_ms: 1,
+      },
+    ],
+    ...overrides,
+  },
+  error: undefined,
+})
+
+describe("CatalogSearchInstantSearchAdapter", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    postMultiSearchMock.mockReset()
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  describe("included-block warn-once", () => {
+    it("logs console.warn exactly once when include is configured but the response lacks an included block, even across multiple search calls", async () => {
+      // Response has hits + relationships but no top-level `included`.
+      postMultiSearchMock.mockResolvedValue(buildResponse())
+
+      const adapter = new CatalogSearchInstantSearchAdapter({
+        client: { setConfig: () => {} } as any,
+        additionalSearchParameters: { query_by: "name" },
+        include: ["main_image"],
+      } as any)
+
+      await adapter.searchClient.search([
+        { indexName: "products", params: { query: "*" } },
+      ])
+      await adapter.searchClient.search([
+        { indexName: "products", params: { query: "leather" } },
+      ])
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not warn when include is configured AND the response carries an included block (even if empty for the requested resource)", async () => {
+      postMultiSearchMock.mockResolvedValue(
+        buildResponse({ included: {} }),
+      )
+
+      const adapter = new CatalogSearchInstantSearchAdapter({
+        client: { setConfig: () => {} } as any,
+        additionalSearchParameters: { query_by: "name" },
+        include: ["main_image"],
+      } as any)
+
+      await adapter.searchClient.search([
+        { indexName: "products", params: { query: "*" } },
+      ])
+
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it("does not warn when include is not configured, regardless of the response shape", async () => {
+      postMultiSearchMock.mockResolvedValue(buildResponse())
+
+      const adapter = new CatalogSearchInstantSearchAdapter({
+        client: { setConfig: () => {} } as any,
+        additionalSearchParameters: { query_by: "name" },
+      } as any)
+
+      await adapter.searchClient.search([
+        { indexName: "products", params: { query: "*" } },
+      ])
+
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/catalog-search-instantsearch-adapter/src/CatalogSearchInstantSearchAdapter.ts
+++ b/packages/catalog-search-instantsearch-adapter/src/CatalogSearchInstantSearchAdapter.ts
@@ -40,6 +40,7 @@ export default class CatalogSearchInstantSearchAdapter {
   configuration: Configuration
   shopperClient: ShopperSearchClient
   searchClient: SearchClient & { clearCache: () => SearchClient }
+  private didWarnIncludedMissing = false
 
   constructor(options: AdapterOptions) {
     this.shopperClient = options.client
@@ -77,6 +78,7 @@ export default class CatalogSearchInstantSearchAdapter {
           typesenseResponse,
         )
         let adaptedResponse = responseAdapter.adapt()
+        this._maybeWarnIncludedMissing(responseAdapter)
 
         // InstantSearch expects one result per request, so return the same adapted response for each request
         const adaptedResponses = instantsearchRequests.map(
@@ -100,6 +102,7 @@ export default class CatalogSearchInstantSearchAdapter {
               multiSearchResponse,
             )
             let adaptedResponse = responseAdapter.adapt()
+            this._maybeWarnIncludedMissing(responseAdapter)
 
             return adaptedResponse
           }) ?? []
@@ -170,6 +173,15 @@ export default class CatalogSearchInstantSearchAdapter {
       this.shopperClient = options.client
     }
     return true
+  }
+
+  private _maybeWarnIncludedMissing(responseAdapter: SearchResponseAdapter): void {
+    if (responseAdapter.needsIncludedWarning && !this.didWarnIncludedMissing) {
+      this.didWarnIncludedMissing = true
+      console.warn(
+        "[catalog-search-instantsearch-adapter] `include` was configured but the catalog-search response did not contain an `included` block. Related resources (e.g. main_image) will not be merged onto hits. Verify the EP catalog-search server honours the `include` query parameter.",
+      )
+    }
   }
 
   _validateTypesenseResult(typesenseResult: TypesenseResult): void {

--- a/packages/catalog-search-instantsearch-adapter/src/Configuration.test.ts
+++ b/packages/catalog-search-instantsearch-adapter/src/Configuration.test.ts
@@ -51,6 +51,31 @@ describe("Configuration", () => {
         expect(subject.union).toBe(true)
       })
     })
+
+    describe("include parameter", () => {
+      it("defaults include to undefined when not provided", () => {
+        const subject = new Configuration({
+          additionalSearchParameters: { query_by: "name" },
+        })
+        expect(subject.include).toBeUndefined()
+      })
+
+      it("preserves the configured include array", () => {
+        const subject = new Configuration({
+          additionalSearchParameters: { query_by: "name" },
+          include: ["main_image", "files"],
+        })
+        expect(subject.include).toEqual(["main_image", "files"])
+      })
+
+      it("preserves an explicitly empty include array", () => {
+        const subject = new Configuration({
+          additionalSearchParameters: { query_by: "name" },
+          include: [],
+        })
+        expect(subject.include).toEqual([])
+      })
+    })
   })
 
   describe(".validate", () => {

--- a/packages/catalog-search-instantsearch-adapter/src/Configuration.ts
+++ b/packages/catalog-search-instantsearch-adapter/src/Configuration.ts
@@ -46,6 +46,18 @@ interface CollectionSpecificOptions {
   }
 }
 
+/**
+ * Top-level resources to include in each multi-search response. Mirrors the
+ * EP Shopper SDK's `query.include` parameter on `/catalog/multi-search` —
+ * when set, the response carries a sibling `included` object keyed by
+ * resource type (`main_images`, `files`, `component_products`) that the
+ * consumer can join to each hit's `relationships.<resource>.data.id`.
+ */
+export type CatalogSearchIncludeResource =
+  | "files"
+  | "main_image"
+  | "component_products"
+
 interface ConfigurationOptions {
   server?: Server // Deprecated - for backward compatibility
   client?: any // Pre-configured Shopper SDK client instance
@@ -63,6 +75,12 @@ interface ConfigurationOptions {
   collectionSpecificFilterByOptions?: CollectionSpecificOptions
   collectionSpecificSortByOptions?: CollectionSpecificOptions
   union?: boolean
+  /**
+   * Resources to inline alongside hits in the multi-search response. Maps
+   * to the `?include=` URL query parameter on `/catalog/multi-search`. When
+   * unset (default), no `include` is sent and behaviour is unchanged.
+   */
+  include?: CatalogSearchIncludeResource[]
 }
 
 export class Configuration {
@@ -81,6 +99,7 @@ export class Configuration {
   collectionSpecificFilterByOptions: CollectionSpecificOptions
   collectionSpecificSortByOptions: CollectionSpecificOptions
   union: boolean
+  include?: CatalogSearchIncludeResource[]
 
   constructor(options: ConfigurationOptions = {}) {
     // Store client reference and headers
@@ -147,6 +166,7 @@ export class Configuration {
     this.collectionSpecificSortByOptions =
       options.collectionSpecificSortByOptions ?? {}
     this.union = options.union ?? false
+    this.include = options.include
   }
 
   validate(): void {

--- a/packages/catalog-search-instantsearch-adapter/src/SearchRequestAdapter.test.ts
+++ b/packages/catalog-search-instantsearch-adapter/src/SearchRequestAdapter.test.ts
@@ -495,6 +495,98 @@ describe("SearchRequestAdapter", () => {
         })
       })
 
+      it("forwards configured `include` as the postMultiSearch `query.include`", async () => {
+        const configuration = new Configuration({
+          additionalSearchParameters: {
+            query_by: "name",
+          },
+          include: ["main_image", "files"],
+        })
+
+        const instantsearchRequests = [
+          {
+            indexName: "products",
+            params: { query: "test" },
+          },
+        ]
+
+        const subject = new SearchRequestAdapter(
+          instantsearchRequests,
+          client,
+          configuration,
+        )
+        await subject.request()
+
+        expect(postMultiSearch).toHaveBeenCalledWith({
+          client,
+          body: {
+            searches: [
+              {
+                type: "products",
+                q: "test",
+                page: 1,
+                query_by: "name",
+                highlight_full_fields: "name",
+              },
+            ],
+          },
+          headers: {},
+          query: { include: ["main_image", "files"] },
+        })
+      })
+
+      it("omits `query.include` from postMultiSearch when `include` is not configured", async () => {
+        const configuration = new Configuration({
+          additionalSearchParameters: {
+            query_by: "name",
+          },
+        })
+
+        const instantsearchRequests = [
+          {
+            indexName: "products",
+            params: { query: "test" },
+          },
+        ]
+
+        const subject = new SearchRequestAdapter(
+          instantsearchRequests,
+          client,
+          configuration,
+        )
+        await subject.request()
+
+        const call = (postMultiSearch as any).mock.calls.at(-1)?.[0]
+        expect(call).toBeDefined()
+        expect(call).not.toHaveProperty("query")
+      })
+
+      it("omits `query.include` from postMultiSearch when `include` is an empty array", async () => {
+        const configuration = new Configuration({
+          additionalSearchParameters: {
+            query_by: "name",
+          },
+          include: [],
+        })
+
+        const instantsearchRequests = [
+          {
+            indexName: "products",
+            params: { query: "test" },
+          },
+        ]
+
+        const subject = new SearchRequestAdapter(
+          instantsearchRequests,
+          client,
+          configuration,
+        )
+        await subject.request()
+
+        const call = (postMultiSearch as any).mock.calls.at(-1)?.[0]
+        expect(call).not.toHaveProperty("query")
+      })
+
       it("does not include union parameter in multisearch request when union is not configured", async () => {
         const configuration = new Configuration({
           additionalSearchParameters: {

--- a/packages/catalog-search-instantsearch-adapter/src/SearchRequestAdapter.ts
+++ b/packages/catalog-search-instantsearch-adapter/src/SearchRequestAdapter.ts
@@ -721,11 +721,20 @@ export class SearchRequestAdapter {
       commonParams.page = searches[0].page
     }
 
-    // Use the shopper SDK's postMultiSearch function
+    // Use the shopper SDK's postMultiSearch function. When `include` is
+    // configured, forward it as the `?include=` URL query so EP returns a
+    // top-level `included` block alongside hits — letting the consumer join
+    // image / file / component-product resources to each hit's
+    // relationships without an extra round-trip. Conditional spread so the
+    // call site is byte-for-byte identical when `include` is unset, keeping
+    // existing call-arg assertions in tests stable.
     const response = await postMultiSearch({
       client: this.shopperClient,
       body: searchRequest,
       headers: this.configuration.headers || {},
+      ...(this.configuration.include && this.configuration.include.length > 0
+        ? { query: { include: this.configuration.include } }
+        : {}),
       ...commonParams,
     })
 

--- a/packages/catalog-search-instantsearch-adapter/src/SearchResponseAdapter.test.ts
+++ b/packages/catalog-search-instantsearch-adapter/src/SearchResponseAdapter.test.ts
@@ -1,9 +1,115 @@
 import { describe, it, expect } from "vitest"
+import { SearchResponseAdapter } from "./SearchResponseAdapter"
+import { Configuration } from "./Configuration"
 
 describe("SearchResponseAdapter", () => {
   // TODO: await final response shape from catalog search
   it("placeholder", () => {
     expect(true).toBe(true)
+  })
+
+  describe("included-resource merge", () => {
+    it("merges included main_image onto each hit when configuration.include is set", () => {
+      const typesenseResult = {
+        found: 1,
+        hits: [
+          {
+            document: {
+              id: "p1",
+              relationships: {
+                main_image: { data: { id: "img-1", type: "main_image" } },
+              },
+            },
+            highlights: [],
+            highlight: {},
+          },
+        ],
+        page: 1,
+        request_params: { q: "*", per_page: 10 },
+        search_time_ms: 1,
+      }
+      const fullResponse = {
+        included: {
+          main_images: [
+            {
+              id: "img-1",
+              link: { href: "https://cdn.example.com/img-1.jpg" },
+              mime_type: "image/jpeg",
+            },
+          ],
+        },
+        results: [typesenseResult],
+      }
+      const configuration = new Configuration({
+        additionalSearchParameters: { query_by: "name" },
+        include: ["main_image"],
+      })
+
+      const subject = new SearchResponseAdapter(
+        typesenseResult as any,
+        { indexName: "products", params: { query: "*" } } as any,
+        configuration,
+        [typesenseResult] as any,
+        fullResponse as any,
+      )
+
+      const result = subject.adapt()
+
+      expect(result.hits).toHaveLength(1)
+      expect(result.hits[0]).toMatchObject({
+        objectID: "p1",
+        main_image: {
+          id: "img-1",
+          link: { href: "https://cdn.example.com/img-1.jpg" },
+        },
+      })
+    })
+
+    it("does not merge when configuration.include is not set", () => {
+      const typesenseResult = {
+        found: 1,
+        hits: [
+          {
+            document: {
+              id: "p1",
+              relationships: {
+                main_image: { data: { id: "img-1", type: "main_image" } },
+              },
+            },
+            highlights: [],
+            highlight: {},
+          },
+        ],
+        page: 1,
+        request_params: { q: "*", per_page: 10 },
+        search_time_ms: 1,
+      }
+      const fullResponse = {
+        // included is present in the response, but configuration.include is unset —
+        // adapter should not perform the merge speculatively.
+        included: {
+          main_images: [
+            { id: "img-1", link: { href: "https://cdn.example.com/img-1.jpg" } },
+          ],
+        },
+        results: [typesenseResult],
+      }
+      const configuration = new Configuration({
+        additionalSearchParameters: { query_by: "name" },
+      })
+
+      const subject = new SearchResponseAdapter(
+        typesenseResult as any,
+        { indexName: "products", params: { query: "*" } } as any,
+        configuration,
+        [typesenseResult] as any,
+        fullResponse as any,
+      )
+
+      const result = subject.adapt()
+
+      expect(result.hits[0]).not.toHaveProperty("main_image")
+    })
   })
   // describe("._adaptHighlightResult", () => {
   //   it("adapts the given hit's highlight", () => {

--- a/packages/catalog-search-instantsearch-adapter/src/SearchResponseAdapter.ts
+++ b/packages/catalog-search-instantsearch-adapter/src/SearchResponseAdapter.ts
@@ -4,6 +4,7 @@ import { utils } from "./support/utils"
 import type { Configuration } from "./Configuration"
 import type { SearchOptions } from "algoliasearch-helper/types/algoliasearch"
 import { MultiSearchResponse, SearchResult } from "@epcc-sdk/sdks-shopper"
+import { mergeIncludedResources } from "./included-merge"
 
 // InstantSearch.js sends requests in this format
 interface SearchRequest {
@@ -104,6 +105,15 @@ export class SearchResponseAdapter {
   // fullTypesenseResponse: MultiSearchResponse
   allTypesenseResults: any
   fullTypesenseResponse: any
+  /**
+   * Set as a side effect of `.adapt()` when `configuration.include` was
+   * configured but the response carried no `included` block. The caller
+   * (`CatalogSearchInstantSearchAdapter`) reads this after each adapt and
+   * decides whether to log a `console.warn` — gated by its own
+   * "warn-once-per-adapter-instance" flag so a misconfigured server doesn't
+   * flood the console.
+   */
+  needsIncludedWarning: boolean = false
   _adaptHighlightTag: typeof utils._adaptHighlightTag
   _adaptNumberOfPages: typeof utils._adaptNumberOfPages
 
@@ -586,6 +596,23 @@ export class SearchResponseAdapter {
           _rawTypesenseConversation: this.fullTypesenseResponse.conversation,
         } as AdaptedHit,
       ]
+    }
+
+    // Merge `included` resources onto each hit when the consumer opted into
+    // them via Configuration.include. Pure transform that keeps each hit's
+    // `_rawTypesenseHit` untouched — the resolved fields land as siblings on
+    // the adapted hit only. The merge function returns a flag when the
+    // response carried no `included` block at all (server-side mismatch);
+    // the parent CatalogSearchInstantSearchAdapter reads
+    // `this.needsIncludedWarning` and warns once per instance.
+    if (this.configuration.include && this.configuration.include.length > 0) {
+      const merged = mergeIncludedResources({
+        hits: adaptedResult.hits,
+        included: this.fullTypesenseResponse?.included,
+        includeRequested: this.configuration.include,
+      })
+      adaptedResult.hits = merged.hits as AdaptedHit[]
+      this.needsIncludedWarning = merged.needsIncludedWarning
     }
 
     // console.log(adaptedResult);

--- a/packages/catalog-search-instantsearch-adapter/src/included-merge.test.ts
+++ b/packages/catalog-search-instantsearch-adapter/src/included-merge.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect } from "vitest"
+import { mergeIncludedResources } from "./included-merge"
+
+describe("mergeIncludedResources", () => {
+  it("resolves a single main_image relationship onto the hit when include is configured", () => {
+    const hits = [
+      {
+        objectID: "p1",
+        relationships: {
+          main_image: { data: { id: "img-1", type: "main_image" } },
+        },
+      },
+    ]
+    const included = {
+      main_images: [
+        {
+          id: "img-1",
+          type: "file",
+          link: { href: "https://cdn.example.com/img-1.jpg" },
+          mime_type: "image/jpeg",
+        },
+      ],
+    }
+
+    const result = mergeIncludedResources({
+      hits,
+      included,
+      includeRequested: ["main_image"],
+    })
+
+    expect(result.hits[0]).toMatchObject({
+      objectID: "p1",
+      main_image: {
+        id: "img-1",
+        link: { href: "https://cdn.example.com/img-1.jpg" },
+      },
+    })
+    expect(result.needsIncludedWarning).toBe(false)
+  })
+
+  it("resolves a files relationship as an ordered array of records", () => {
+    const hits = [
+      {
+        objectID: "p1",
+        relationships: {
+          files: {
+            data: [
+              { id: "f-3", type: "file" },
+              { id: "f-1", type: "file" },
+              { id: "f-2", type: "file" },
+            ],
+          },
+        },
+      },
+    ]
+    const included = {
+      // Deliberately stored out of order — the merged array should follow
+      // the relationships.files.data order, not the included order.
+      files: [
+        { id: "f-1", link: { href: "https://cdn.example.com/f-1.jpg" } },
+        { id: "f-2", link: { href: "https://cdn.example.com/f-2.jpg" } },
+        { id: "f-3", link: { href: "https://cdn.example.com/f-3.jpg" } },
+      ],
+    }
+
+    const result = mergeIncludedResources({
+      hits,
+      included,
+      includeRequested: ["files"],
+    })
+
+    expect(result.hits[0].files).toEqual([
+      { id: "f-3", link: { href: "https://cdn.example.com/f-3.jpg" } },
+      { id: "f-1", link: { href: "https://cdn.example.com/f-1.jpg" } },
+      { id: "f-2", link: { href: "https://cdn.example.com/f-2.jpg" } },
+    ])
+    expect(result.needsIncludedWarning).toBe(false)
+  })
+
+  it("leaves the resolved field undefined when a relationship references an id not present in included", () => {
+    const hits = [
+      {
+        objectID: "p1",
+        relationships: {
+          main_image: { data: { id: "img-missing", type: "main_image" } },
+        },
+      },
+    ]
+    const included = {
+      main_images: [
+        { id: "img-other", link: { href: "https://cdn.example.com/other.jpg" } },
+      ],
+    }
+
+    const result = mergeIncludedResources({
+      hits,
+      included,
+      includeRequested: ["main_image"],
+    })
+
+    expect(result.hits[0]).not.toHaveProperty("main_image")
+    expect(result.needsIncludedWarning).toBe(false)
+  })
+
+  it("filters out unresolved entries from an array resource without dropping the array entirely", () => {
+    const hits = [
+      {
+        objectID: "p1",
+        relationships: {
+          files: {
+            data: [
+              { id: "f-present", type: "file" },
+              { id: "f-missing", type: "file" },
+            ],
+          },
+        },
+      },
+    ]
+    const included = {
+      files: [
+        { id: "f-present", link: { href: "https://cdn.example.com/present.jpg" } },
+      ],
+    }
+
+    const result = mergeIncludedResources({
+      hits,
+      included,
+      includeRequested: ["files"],
+    })
+
+    expect(result.hits[0].files).toEqual([
+      { id: "f-present", link: { href: "https://cdn.example.com/present.jpg" } },
+    ])
+    expect(result.needsIncludedWarning).toBe(false)
+  })
+
+  it("flags needsIncludedWarning when include was requested but the response has no included block", () => {
+    const hits = [
+      {
+        objectID: "p1",
+        relationships: {
+          main_image: { data: { id: "img-1", type: "main_image" } },
+        },
+      },
+    ]
+
+    const result = mergeIncludedResources({
+      hits,
+      included: undefined,
+      includeRequested: ["main_image"],
+    })
+
+    expect(result.needsIncludedWarning).toBe(true)
+    // Hits stay un-resolved; the merge couldn't do its job
+    expect(result.hits[0]).not.toHaveProperty("main_image")
+  })
+
+  it("does not flag a warning when include was requested and the included block is present but empty for that resource", () => {
+    // included exists at top level but the requested resource collection is
+    // either missing or empty — that's a "no records matched" case (Q5 case 2),
+    // not a "server didn't honour my include" case (Q5 case 1).
+    const hits = [
+      {
+        objectID: "p1",
+        relationships: {
+          main_image: { data: { id: "img-1", type: "main_image" } },
+        },
+      },
+    ]
+
+    const result = mergeIncludedResources({
+      hits,
+      included: {},
+      includeRequested: ["main_image"],
+    })
+
+    expect(result.needsIncludedWarning).toBe(false)
+    expect(result.hits[0]).not.toHaveProperty("main_image")
+  })
+
+  it("returns hits unchanged and does not flag a warning when includeRequested is undefined", () => {
+    const hits = [
+      {
+        objectID: "p1",
+        relationships: {
+          main_image: { data: { id: "img-1", type: "main_image" } },
+        },
+      },
+    ]
+    const included = {
+      main_images: [{ id: "img-1", link: { href: "https://x" } }],
+    }
+
+    const result = mergeIncludedResources({
+      hits,
+      included,
+      includeRequested: undefined,
+    })
+
+    expect(result.hits[0]).not.toHaveProperty("main_image")
+    expect(result.needsIncludedWarning).toBe(false)
+  })
+
+  it("returns hits unchanged and does not flag a warning when includeRequested is an empty array", () => {
+    const hits = [
+      {
+        objectID: "p1",
+        relationships: {
+          main_image: { data: { id: "img-1", type: "main_image" } },
+        },
+      },
+    ]
+    const included = {
+      main_images: [{ id: "img-1", link: { href: "https://x" } }],
+    }
+
+    const result = mergeIncludedResources({
+      hits,
+      included,
+      includeRequested: [],
+    })
+
+    expect(result.hits[0]).not.toHaveProperty("main_image")
+    expect(result.needsIncludedWarning).toBe(false)
+  })
+
+  it("resolves multiple resource types in a single call", () => {
+    const hits = [
+      {
+        objectID: "p1",
+        relationships: {
+          main_image: { data: { id: "img-1", type: "main_image" } },
+          files: { data: [{ id: "f-1", type: "file" }] },
+        },
+      },
+    ]
+    const included = {
+      main_images: [
+        { id: "img-1", link: { href: "https://cdn/img.jpg" } },
+      ],
+      files: [{ id: "f-1", link: { href: "https://cdn/f-1.jpg" } }],
+    }
+
+    const result = mergeIncludedResources({
+      hits,
+      included,
+      includeRequested: ["main_image", "files"],
+    })
+
+    expect(result.hits[0].main_image).toEqual({
+      id: "img-1",
+      link: { href: "https://cdn/img.jpg" },
+    })
+    expect(result.hits[0].files).toEqual([
+      { id: "f-1", link: { href: "https://cdn/f-1.jpg" } },
+    ])
+  })
+
+  it("does not mutate the input hit objects", () => {
+    const inputHit = {
+      objectID: "p1",
+      _rawTypesenseHit: {
+        document: {
+          relationships: {
+            main_image: { data: { id: "img-1", type: "main_image" } },
+          },
+        },
+      },
+      relationships: {
+        main_image: { data: { id: "img-1", type: "main_image" } },
+      },
+    }
+    const inputHitSnapshot = JSON.parse(JSON.stringify(inputHit))
+    const included = {
+      main_images: [
+        { id: "img-1", link: { href: "https://cdn/img.jpg" } },
+      ],
+    }
+
+    const result = mergeIncludedResources({
+      hits: [inputHit],
+      included,
+      includeRequested: ["main_image"],
+    })
+
+    // Result has the merged field
+    expect(result.hits[0].main_image).toBeDefined()
+    // Input was not touched (in particular, _rawTypesenseHit stays clean)
+    expect(inputHit).toEqual(inputHitSnapshot)
+    expect(result.hits[0]).not.toBe(inputHit)
+  })
+})

--- a/packages/catalog-search-instantsearch-adapter/src/included-merge.ts
+++ b/packages/catalog-search-instantsearch-adapter/src/included-merge.ts
@@ -1,0 +1,83 @@
+"use strict"
+
+import type { CatalogSearchIncludeResource } from "./Configuration"
+
+interface IncludedBlock {
+  main_images?: any[]
+  files?: any[]
+  component_products?: any[]
+}
+
+interface MergeArgs {
+  hits: any[]
+  included: IncludedBlock | undefined
+  includeRequested: CatalogSearchIncludeResource[] | undefined
+}
+
+interface MergeResult {
+  hits: any[]
+  needsIncludedWarning: boolean
+}
+
+/**
+ * Map each `include` value (the singular relationship key on a hit) to its
+ * matching included-block key (always plural in EP responses) and the
+ * cardinality of the resolved field on the hit.
+ *
+ *   include="main_image"        → relationships.main_image.data: { id }     → hit.main_image: object
+ *   include="files"             → relationships.files.data:     [{id}, …]   → hit.files: array
+ *   include="component_products"→ relationships.component_products.data: …  → hit.component_products: array
+ *
+ * The pluralisation special case is `main_image → main_images`; the other
+ * two are already plural on both sides.
+ */
+const RESOURCE_MAP: Record<
+  CatalogSearchIncludeResource,
+  { includedKey: keyof IncludedBlock; cardinality: "single" | "array" }
+> = {
+  main_image: { includedKey: "main_images", cardinality: "single" },
+  files: { includedKey: "files", cardinality: "array" },
+  component_products: {
+    includedKey: "component_products",
+    cardinality: "array",
+  },
+}
+
+export function mergeIncludedResources(args: MergeArgs): MergeResult {
+  const { hits, included, includeRequested } = args
+
+  // Whole-block mismatch: caller asked the server to include resources, but
+  // the response carries no `included` sibling at all. That's a server-side
+  // mismatch worth surfacing once. Per-resource gaps (the `included` block
+  // is present but the requested collection is missing or empty) are normal
+  // data variability — we don't flag those.
+  const needsIncludedWarning =
+    !!includeRequested && includeRequested.length > 0 && included == null
+
+  const mergedHits = hits.map((hit) => {
+    let next: any = hit
+    for (const resource of includeRequested ?? []) {
+      const { includedKey, cardinality } = RESOURCE_MAP[resource]
+      const pool = included?.[includedKey]
+      const relData = hit?.relationships?.[resource]?.data
+      if (cardinality === "single") {
+        const id = relData?.id
+        if (!id) continue
+        const resolved = pool?.find((r) => r?.id === id)
+        if (!resolved) continue
+        next = { ...next, [resource]: resolved }
+      } else {
+        const refs = Array.isArray(relData) ? relData : []
+        if (refs.length === 0) continue
+        const resolved = refs
+          .map((ref) => pool?.find((r) => r?.id === ref?.id))
+          .filter((r) => r != null)
+        if (resolved.length === 0) continue
+        next = { ...next, [resource]: resolved }
+      }
+    }
+    return next
+  })
+
+  return { hits: mergedHits, needsIncludedWarning }
+}


### PR DESCRIPTION
## Summary

Closes elasticpath/composable-frontend#517.

Adds end-to-end support for EP's `?include=` URL query parameter on catalog-search:

1. **Request side** — typed `include` config option (`"main_image" | "files" | "component_products"`) forwards as `query: { include: [...] }` on the `postMultiSearch` call.
2. **Response side** — new `mergeIncludedResources` deep module joins each hit's `relationships.<resource>.data.id` references against the returned `included` block and inlines the resolved record(s) directly onto the hit (`hit.main_image`, `hit.files`, `hit.component_products`) — so consumers can render rich content without a separate per-hit (or per-page-batch) round-trip.
3. **Misconfiguration signal** — if the server omits the `included` block entirely while `include` was requested, the adapter logs a single `console.warn` per instance.

```ts
const adapter = new CatalogSearchInstantSearchAdapter({
  client,
  additionalSearchParameters: { query_by: "name,description" },
  include: ["main_image"],
})

// In a Hits widget:
const Hit = ({ hit }) => (
  <article>
    {hit.main_image && <img src={hit.main_image.link.href} alt={hit.name} />}
    <h3>{hit.name}</h3>
  </article>
)
```

Cardinality follows the EP relationship shape:

| `include` value          | Resolved field on hit       | Type                            |
| ------------------------ | --------------------------- | ------------------------------- |
| `"main_image"`           | `hit.main_image`            | single record or `undefined`    |
| `"files"`                | `hit.files`                 | array (in relationships order)  |
| `"component_products"`   | `hit.component_products`    | array (in relationships order)  |

Backward compatibility is preserved: omit `include` (or pass `[]`) and the adapter neither forwards a `query` field nor performs any merge step — request and hit shape are byte-for-byte identical to before.

## Implementation notes

- The merge lives in a standalone pure module (`included-merge.ts`) — small interface, deep behaviour, no class state. Mapping from singular include name → plural `included` key is captured in a static `RESOURCE_MAP` so the special case (`main_image → main_images`) is local and obvious.
- `SearchResponseAdapter` calls the merge at the end of `adapt()` only when `configuration.include` is non-empty, and stashes a `needsIncludedWarning` flag on itself.
- `CatalogSearchInstantSearchAdapter` reads that flag after each adapt and emits the once-per-instance `console.warn`.
- Missing references (a relationship pointing at an id not present in `included`) are skipped silently — the field is left absent rather than set to a partial record.
- An `included` block that's present but empty for the requested resource is treated as normal data variability (no warn) — only a wholly missing `included` block triggers the warning.
- Input hits are never mutated.

## Test plan

- [x] 14 Configuration tests (existing + 3 new for `include`)
- [x] 20 SearchRequestAdapter tests (existing + 3 new for `query.include` forwarding / omission)
- [x] 10 `included-merge` tests (new module — covers every cardinality + edge case)
- [x] 3 SearchResponseAdapter integration tests (new — merge runs / doesn't run based on config)
- [x] 3 `CatalogSearchInstantSearchAdapter` warn-once tests (new — once across multiple search calls, no warn when included present, no warn when include unset)
- [x] 50/50 tests passing across 5 files
- [x] `pnpm build` clean (DTS generation succeeds for both ESM and CJS)
- [ ] Wire-up in a downstream consumer (Plasmic catalog-search components) — tracked separately as elasticpath/plasmic#301, blocked on this PR

## Changeset

A minor bump is staged in `.changeset/catalog-search-include.md`.